### PR TITLE
[Feature] 소셜로그인(Kakao) 기능 개발

### DIFF
--- a/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
@@ -8,11 +8,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.traveljournal.domain.auth.dto.KakaoCodeRequest;
 import com.traveljournal.domain.auth.dto.LoginCombinedResponse;
 import com.traveljournal.domain.auth.dto.LoginResponse;
 import com.traveljournal.domain.auth.service.AuthService;
 import com.traveljournal.global.data.ApiResponse;
+import com.traveljournal.global.security.jwt.JwtTokenProvider;
 import com.traveljournal.global.security.util.SecurityUtil;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AuthController {
 
 	private final AuthService authService;
+	private final JwtTokenProvider jwtTokenProvider;
 
 	/**
 	 * 카카오 로그인 콜백 처리
@@ -46,8 +47,8 @@ public class AuthController {
 		@Parameter(description = "디바이스 ID (선택 사항)")
 		@RequestParam(required = false) String deviceId) {
 
-		LoginCombinedResponse response = authService.processKakaoLoginWithCode(new KakaoCodeRequest(code), deviceId);
-		return ApiResponse.accessTokenResponse(response.LoginResponse(), response.accessToken());
+		LoginCombinedResponse loginCombinedResponse = authService.processKakaoLoginWithCode(code, deviceId);
+		return ApiResponse.accessTokenResponse(loginCombinedResponse.LoginResponse(), loginCombinedResponse.accessToken());
 	}
 
 	@Operation(
@@ -60,15 +61,13 @@ public class AuthController {
 		@RequestHeader("Authorization") String authorizationHeader,
 		@RequestParam(required = false) String deviceId
 	) {
-		if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-			throw new IllegalArgumentException("유효한 Authorization 헤더가 필요합니다.");
-		}
-		String idToken = authorizationHeader.substring(7);
+		String idToken = jwtTokenProvider.resolveToken(authorizationHeader);
 
-		LoginCombinedResponse response = authService.processKakaoLoginWithIdToken(idToken, deviceId);
+		LoginCombinedResponse loginCombinedResponse = authService.processKakaoLoginWithIdToken(idToken, deviceId);
 
-		return ApiResponse.accessTokenResponse(response.LoginResponse(), response.accessToken());
+		return ApiResponse.accessTokenResponse(loginCombinedResponse.LoginResponse(), loginCombinedResponse.accessToken());
 	}
+
 
 	/**
 	 * 로그아웃 처리

--- a/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
@@ -1,0 +1,89 @@
+package com.traveljournal.domain.auth.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.traveljournal.domain.auth.dto.KakaoCodeRequest;
+import com.traveljournal.domain.auth.dto.LoginCombinedResponse;
+import com.traveljournal.domain.auth.dto.LoginResponse;
+import com.traveljournal.domain.auth.service.AuthService;
+import com.traveljournal.global.data.ApiResponse;
+import com.traveljournal.global.security.util.SecurityUtil;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/auth")
+@Tag(name = "Auth API", description = "로그인 및 로그아웃 관련 API")
+public class AuthController {
+
+	private final AuthService authService;
+
+	/**
+	 * 카카오 로그인 콜백 처리
+	 * 카카오 인증 코드를 받아 로그인/회원가입 처리 후 토큰 발급
+	 */
+	@Operation(
+		summary = "Kakao Login callback",
+		description = "카카오 인증 코드를 받아 로그인/회원가입 후 헤더에 액세스 토큰을 발급합니다."
+	)
+	@GetMapping("/kakao/callback")
+	public ResponseEntity<LoginResponse> kakaoCallback(
+		@Parameter(description = "카카오에서 반환한 인증 코드", required = true)
+		@RequestParam String code,
+		@Parameter(description = "디바이스 ID (선택 사항)")
+		@RequestParam(required = false) String deviceId) {
+
+		LoginCombinedResponse response = authService.processKakaoLoginWithCode(new KakaoCodeRequest(code), deviceId);
+		return ApiResponse.accessTokenResponse(response.LoginResponse(), response.accessToken());
+	}
+
+	@Operation(
+		summary = "Kakao ID Token Login",
+		description = "카카오 ID 토큰을 이용한 로그인. Bearer 토큰을 Authorization 헤더에 포함해야 합니다.",
+		security = @SecurityRequirement(name = "bearer-key")
+	)
+	@PostMapping("/kakao/id-token-login")
+	public ResponseEntity<LoginResponse> kakaoLoginWithIdToken(
+		@RequestHeader("Authorization") String authorizationHeader,
+		@RequestParam(required = false) String deviceId
+	) {
+		if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+			throw new IllegalArgumentException("유효한 Authorization 헤더가 필요합니다.");
+		}
+		String idToken = authorizationHeader.substring(7);
+
+		LoginCombinedResponse response = authService.processKakaoLoginWithIdToken(idToken, deviceId);
+
+		return ApiResponse.accessTokenResponse(response.LoginResponse(), response.accessToken());
+	}
+
+	/**
+	 * 로그아웃 처리
+	 * 특정 장치에서 로그아웃 시 해당 장치의 토큰 삭제
+	 */
+	@Operation(
+		summary = "Logout",
+		description = "특정 장치에서 로그아웃을 처리하고 해당 장치의 토큰을 삭제합니다.",
+		security = @SecurityRequirement(name = "bearer-key")
+	)
+	@PostMapping("/logout")
+	public ResponseEntity<?> logout(@RequestParam String deviceId) {
+		Long memberId = SecurityUtil.getCurrentMemberId();
+
+		authService.logout(memberId, deviceId);
+		return ApiResponse.success("로그아웃되었습니다.");
+	}
+}

--- a/src/main/java/com/traveljournal/domain/auth/dto/FirstLoginRequest.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/FirstLoginRequest.java
@@ -1,0 +1,9 @@
+package com.traveljournal.domain.auth.dto;
+
+import com.traveljournal.domain.member.entity.AccountScope;
+
+public record FirstLoginRequest(
+	String nickname,
+	AccountScope accountScope
+) {
+}

--- a/src/main/java/com/traveljournal/domain/auth/dto/KakaoCodeRequest.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/KakaoCodeRequest.java
@@ -1,0 +1,5 @@
+package com.traveljournal.domain.auth.dto;
+
+public record KakaoCodeRequest(
+	String code
+) {}

--- a/src/main/java/com/traveljournal/domain/auth/dto/KakaoCodeRequest.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/KakaoCodeRequest.java
@@ -1,5 +1,0 @@
-package com.traveljournal.domain.auth.dto;
-
-public record KakaoCodeRequest(
-	String code
-) {}

--- a/src/main/java/com/traveljournal/domain/auth/dto/KakaoIdTokenInfo.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/KakaoIdTokenInfo.java
@@ -1,0 +1,11 @@
+package com.traveljournal.domain.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record KakaoIdTokenInfo(
+	String sub,        // 카카오 회원번호 (고유 ID)
+	String email,      // 이메일
+	String nickname,   // 닉네임
+	String profile_image_url     // 프로필 이미지 URL
+) {}

--- a/src/main/java/com/traveljournal/domain/auth/dto/KakaoMemberInfo.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/KakaoMemberInfo.java
@@ -1,0 +1,37 @@
+package com.traveljournal.domain.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record KakaoMemberInfo(
+	Long id,
+	KakaoAccount kakao_account
+) {
+	@Builder
+	public record KakaoAccount(
+		String email,
+		Profile profile
+	) {}
+
+	@Builder
+	public record Profile(
+		String nickname,
+		String profile_image_url
+	) {}
+
+	// of 메서드 추가
+	public static KakaoMemberInfo of(Long id, String email, String nickname, String profileImageUrl) {
+		return KakaoMemberInfo.builder()
+			.id(id)
+			.kakao_account(KakaoAccount.builder()
+				.email(email)
+				.profile(Profile.builder()
+					.nickname(nickname)
+					.profile_image_url(profileImageUrl)
+					.build()
+				)
+				.build()
+			)
+			.build();
+	}
+}

--- a/src/main/java/com/traveljournal/domain/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,11 @@
+package com.traveljournal.domain.auth.dto;
+
+public record KakaoTokenResponse(
+	String access_token,
+	String token_type,
+	String refresh_token,
+	String id_token,
+	int expires_in,
+	String scope,
+	int refresh_token_expires_in
+) {}

--- a/src/main/java/com/traveljournal/domain/auth/dto/LoginCombinedResponse.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/LoginCombinedResponse.java
@@ -1,0 +1,16 @@
+package com.traveljournal.domain.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record LoginCombinedResponse (
+	LoginResponse LoginResponse,
+	String accessToken
+) {
+	public static LoginCombinedResponse of(LoginResponse loginResponse, String accessToken) {
+		return LoginCombinedResponse.builder()
+			.LoginResponse(loginResponse)
+			.accessToken(accessToken)
+			.build();
+	}
+}

--- a/src/main/java/com/traveljournal/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/LoginResponse.java
@@ -1,0 +1,41 @@
+package com.traveljournal.domain.auth.dto;
+
+import java.time.LocalDateTime;
+
+import com.traveljournal.domain.member.dto.TokenInfo;
+import com.traveljournal.domain.member.entity.AccountScope;
+import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.entity.SocialProvider;
+
+import lombok.Builder;
+
+@Builder
+public record LoginResponse(
+	Long memberId,
+	String email,
+	String nickname,
+	String profileImageUrl,
+	LocalDateTime birthdate,
+	AccountScope accountScope,
+	String phoneNumber,
+	SocialProvider socialProvider,
+	boolean isFirstLogin,
+	String refreshToken,
+	String deviceId
+) {
+	public static LoginResponse from(Member member, TokenInfo tokenInfo) {
+		return LoginResponse.builder()
+			.memberId(member.getId())
+			.email(member.getEmail())
+			.nickname(member.getNickname())
+			.profileImageUrl(member.getProfileImageUrl())
+			.birthdate(member.getBirthdate())
+			.accountScope(member.getAccountScope())
+			.phoneNumber(member.getPhoneNumber())
+			.socialProvider(member.getSocialProvider())
+			.isFirstLogin(member.getIsFirstLogin())
+			.refreshToken(tokenInfo.refreshToken())
+			.deviceId(tokenInfo.deviceId())
+			.build();
+	}
+}

--- a/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
@@ -1,0 +1,81 @@
+package com.traveljournal.domain.auth.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.traveljournal.domain.auth.dto.KakaoCodeRequest;
+import com.traveljournal.domain.auth.dto.KakaoIdTokenInfo;
+import com.traveljournal.domain.auth.dto.KakaoMemberInfo;
+import com.traveljournal.domain.auth.dto.KakaoTokenResponse;
+import com.traveljournal.domain.auth.dto.LoginCombinedResponse;
+import com.traveljournal.domain.auth.dto.LoginResponse;
+import com.traveljournal.domain.auth.util.KakaoClient;
+import com.traveljournal.domain.member.dto.TokenInfo;
+import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.service.MemberService;
+import com.traveljournal.domain.member.service.TokenService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final KakaoClient kakaoClient;
+	private final MemberService memberService;
+	private final TokenService tokenService;
+
+	/**
+	 * 카카오 로그인 처리
+	 * 1. 카카오 인증 코드로 액세스 토큰 요청
+	 * 2. 카카오 액세스 토큰으로 사용자 정보 요청
+	 * 3. 이메일로 회원 조회 또는 생성
+	 * 4. JWT 토큰 생성 및 저장
+	 * 5. 로그인 응답 생성
+	 */
+	@Transactional
+	public LoginCombinedResponse processKakaoLoginWithCode(KakaoCodeRequest request, String deviceId) {
+
+		// 카카오 토큰 획득
+		KakaoTokenResponse kakaoToken = kakaoClient.getKakaoToken(request.code());
+
+		return processKakaoLoginWithIdToken(kakaoToken.id_token(), deviceId);
+	}
+
+	@Transactional
+	public LoginCombinedResponse processKakaoLoginWithIdToken(String idToken, String deviceId) {
+
+		// ID Token으로 카카오 사용자 정보 가져오기
+		KakaoIdTokenInfo memberInfo = kakaoClient.getKakaoMemberInfoFromIdToken(idToken);
+
+		// 회원 찾기 또는 생성
+		Member member = memberService.findOrCreateMember(
+			KakaoMemberInfo.of(
+				Long.parseLong(memberInfo.sub()),
+				memberInfo.email(),
+				memberInfo.nickname(),
+				memberInfo.profile_image_url()
+			)
+		);
+
+		// JWT 토큰 생성
+		TokenInfo tokenInfo = tokenService.createTokens(member.getEmail(), deviceId);
+
+		// 토큰 저장
+		tokenService.saveOrUpdateToken(member, tokenInfo.deviceId(), tokenInfo.refreshToken());
+
+		// 회원 정보와 토큰 정보를 포함한 응답 생성
+		return LoginCombinedResponse.of(LoginResponse.from(member, tokenInfo), tokenInfo.accessToken());
+	}
+
+	/**
+	 * 로그아웃 처리
+	 * 특정 장치의 토큰 삭제
+	 */
+	@Transactional
+	public void logout(Long memberId, String deviceId) {
+		tokenService.deleteToken(memberId, deviceId);
+	}
+}

--- a/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
@@ -3,7 +3,6 @@ package com.traveljournal.domain.auth.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.traveljournal.domain.auth.dto.KakaoCodeRequest;
 import com.traveljournal.domain.auth.dto.KakaoIdTokenInfo;
 import com.traveljournal.domain.auth.dto.KakaoMemberInfo;
 import com.traveljournal.domain.auth.dto.KakaoTokenResponse;
@@ -36,27 +35,27 @@ public class AuthService {
 	 * 5. 로그인 응답 생성
 	 */
 	@Transactional
-	public LoginCombinedResponse processKakaoLoginWithCode(KakaoCodeRequest request, String deviceId) {
+	public LoginCombinedResponse processKakaoLoginWithCode(String code, String deviceId) {
 
 		// 카카오 토큰 획득
-		KakaoTokenResponse kakaoToken = kakaoClient.getKakaoToken(request.code());
+		KakaoTokenResponse kakaoTokenResponse = kakaoClient.getKakaoToken(code);
 
-		return processKakaoLoginWithIdToken(kakaoToken.id_token(), deviceId);
+		return processKakaoLoginWithIdToken(kakaoTokenResponse.id_token(), deviceId);
 	}
 
 	@Transactional
 	public LoginCombinedResponse processKakaoLoginWithIdToken(String idToken, String deviceId) {
 
 		// ID Token으로 카카오 사용자 정보 가져오기
-		KakaoIdTokenInfo memberInfo = kakaoClient.getKakaoMemberInfoFromIdToken(idToken);
+		KakaoIdTokenInfo kakaoIdTokenInfo = kakaoClient.getKakaoMemberInfoFromIdToken(idToken);
 
 		// 회원 찾기 또는 생성
 		Member member = memberService.findOrCreateMember(
 			KakaoMemberInfo.of(
-				Long.parseLong(memberInfo.sub()),
-				memberInfo.email(),
-				memberInfo.nickname(),
-				memberInfo.profile_image_url()
+				Long.parseLong(kakaoIdTokenInfo.sub()),
+				kakaoIdTokenInfo.email(),
+				kakaoIdTokenInfo.nickname(),
+				kakaoIdTokenInfo.profile_image_url()
 			)
 		);
 

--- a/src/main/java/com/traveljournal/domain/auth/util/KakaoClient.java
+++ b/src/main/java/com/traveljournal/domain/auth/util/KakaoClient.java
@@ -1,0 +1,116 @@
+package com.traveljournal.domain.auth.util;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.traveljournal.domain.auth.dto.KakaoIdTokenInfo;
+import com.traveljournal.domain.auth.dto.KakaoMemberInfo;
+import com.traveljournal.domain.auth.dto.KakaoTokenResponse;
+import com.traveljournal.global.config.KakaoOAuthConfig;
+import com.traveljournal.global.exception.ExternalApiException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoClient {
+
+	private final RestTemplate restTemplate;
+	private final KakaoOAuthConfig kakaoOAuthConfig;
+
+	/**
+	 * 카카오 인증 코드로 액세스 토큰 얻기
+	 */
+	public KakaoTokenResponse getKakaoToken(String code) {
+		try {
+			HttpHeaders headers = new HttpHeaders();
+			headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+			MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+			params.add("grant_type", "authorization_code");
+			params.add("client_id", kakaoOAuthConfig.getClientId());
+			params.add("client_secret", kakaoOAuthConfig.getClientSecret());
+			params.add("code", code);
+			params.add("redirect_uri", kakaoOAuthConfig.getRedirectUri());
+
+			HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+			KakaoTokenResponse response = restTemplate.postForObject(
+				kakaoOAuthConfig.getTokenUri(),
+				request,
+				KakaoTokenResponse.class
+			);
+
+			if (response == null) {
+				throw new ExternalApiException("카카오 토큰 응답이 null입니다.");
+			}
+
+			log.info("카카오 토큰 발급 성공");
+			return response;
+
+		} catch (Exception e) {
+			log.error("카카오 토큰 발급 실패: {}", e.getMessage());
+			throw new ExternalApiException("카카오 토큰 발급에 실패했습니다: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * 카카오 액세스 토큰으로 사용자 정보 가져오기
+	 */
+	public KakaoMemberInfo getKakaoMemberInfo(String accessToken) {
+		try {
+			HttpHeaders headers = new HttpHeaders();
+			headers.set("Authorization", "Bearer " + accessToken);
+			headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+			HttpEntity<Void> request = new HttpEntity<>(headers);
+
+			KakaoMemberInfo response = restTemplate.exchange(
+				kakaoOAuthConfig.getUserInfoUri(),
+				HttpMethod.GET,
+				request,
+				KakaoMemberInfo.class
+			).getBody();
+
+			if (response == null) {
+				throw new ExternalApiException("카카오 사용자 정보 응답이 null입니다.");
+			}
+
+			log.info("카카오 사용자 정보 조회 성공");
+			return response;
+
+		} catch (Exception e) {
+			log.error("카카오 사용자 정보 조회 실패: {}", e.getMessage());
+			throw new ExternalApiException("카카오 사용자 정보 조회에 실패했습니다: " + e.getMessage());
+		}
+	}
+
+	public KakaoIdTokenInfo getKakaoMemberInfoFromIdToken(String idToken) {
+		try {
+			// ID Token 디코딩
+			SignedJWT signedJWT = SignedJWT.parse(idToken);
+			JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+
+			String sub = claims.getSubject(); // 카카오 회원번호
+			String email = (String) claims.getClaim("email");
+			String nickname = (String) claims.getClaim("nickname");
+			String picture = (String) claims.getClaim("picture"); // 프로필 이미지
+
+			log.info("카카오 ID Token 정보: sub={}, email={}, nickname={}, picture={}", sub, email, nickname, picture);
+			return new KakaoIdTokenInfo(sub, email, nickname, picture);
+		} catch (Exception e) {
+			log.error("ID Token 파싱 실패: {}", e.getMessage());
+			throw new ExternalApiException("ID Token 파싱에 실패했습니다: " + e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/traveljournal/domain/member/controller/MemberController.java
+++ b/src/main/java/com/traveljournal/domain/member/controller/MemberController.java
@@ -1,0 +1,46 @@
+package com.traveljournal.domain.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.traveljournal.domain.auth.dto.FirstLoginRequest;
+import com.traveljournal.domain.member.service.MemberService;
+import com.traveljournal.global.data.ApiResponse;
+import com.traveljournal.global.security.util.SecurityUtil;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/member")
+@Tag(name = "member API", description = "회원 관련 API")
+public class MemberController {
+	private final MemberService memberService;
+
+	/**
+	 * 첫 로그인 완료 처리
+	 * 사용자 온보딩 완료 시 호출
+	 */
+	@Operation(
+		summary = "Complete First Login",
+		description = "사용자 온보딩이 완료되었을 때 호출됩니다.",
+		security = @SecurityRequirement(name = "bearer-key")
+	)
+	@PostMapping("/complete-first-login")
+	public ResponseEntity<?> completeFirstLogin(@RequestBody FirstLoginRequest request) {
+		log.info(request.toString());
+		Long memberId = SecurityUtil.getCurrentMemberId();
+
+
+		memberService.completeFirstLogin(memberId, request);
+		return ApiResponse.success("첫 로그인 완료 처리되었습니다.");
+	}
+}

--- a/src/main/java/com/traveljournal/domain/member/controller/MemberController.java
+++ b/src/main/java/com/traveljournal/domain/member/controller/MemberController.java
@@ -35,12 +35,10 @@ public class MemberController {
 		security = @SecurityRequirement(name = "bearer-key")
 	)
 	@PostMapping("/complete-first-login")
-	public ResponseEntity<?> completeFirstLogin(@RequestBody FirstLoginRequest request) {
-		log.info(request.toString());
+	public ResponseEntity<?> completeFirstLogin(@RequestBody FirstLoginRequest firstLoginRequest) {
 		Long memberId = SecurityUtil.getCurrentMemberId();
 
-
-		memberService.completeFirstLogin(memberId, request);
+		memberService.completeFirstLogin(memberId, firstLoginRequest);
 		return ApiResponse.success("첫 로그인 완료 처리되었습니다.");
 	}
 }

--- a/src/main/java/com/traveljournal/domain/member/controller/TokenController.java
+++ b/src/main/java/com/traveljournal/domain/member/controller/TokenController.java
@@ -7,13 +7,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.traveljournal.domain.member.dto.MemberTokenResponse;
-import com.traveljournal.domain.member.dto.TokenRefreshRequest;
+import com.traveljournal.domain.member.dto.ReissueRequest;
+import com.traveljournal.domain.member.dto.ReissueResonse;
 import com.traveljournal.domain.member.service.TokenService;
 import com.traveljournal.global.data.ApiResponse;
-import com.traveljournal.global.data.ApiResult;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -31,12 +30,11 @@ public class TokenController {
 	 */
 	@Operation(
 		summary = "Token Refresh",
-		description = "Refresh 토큰과 장치 ID를 사용하여 새로운 액세스 토큰을 발급합니다.",
-		security = @SecurityRequirement(name = "bearer-key")
+		description = "Refresh 토큰과 장치 ID를 사용하여 새로운 액세스 토큰을 발급합니다."
 	)
 	@PostMapping("/reissue")
-	public ResponseEntity<ApiResult<MemberTokenResponse>> refreshToken(@RequestBody TokenRefreshRequest request) {
-		MemberTokenResponse response = tokenService.refreshToken(request);
-		return ApiResponse.ok(response);
+	public ResponseEntity<ReissueResonse> refreshToken(@RequestBody ReissueRequest Reissuerequest) {
+		MemberTokenResponse memberTokenResponse = tokenService.refreshToken(Reissuerequest);
+		return ApiResponse.accessTokenResponse(ReissueResonse.of(memberTokenResponse), memberTokenResponse.tokenInfo().accessToken());
 	}
 }

--- a/src/main/java/com/traveljournal/domain/member/controller/TokenController.java
+++ b/src/main/java/com/traveljournal/domain/member/controller/TokenController.java
@@ -1,0 +1,42 @@
+package com.traveljournal.domain.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.traveljournal.domain.member.dto.MemberTokenResponse;
+import com.traveljournal.domain.member.dto.TokenRefreshRequest;
+import com.traveljournal.domain.member.service.TokenService;
+import com.traveljournal.global.data.ApiResponse;
+import com.traveljournal.global.data.ApiResult;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/tokens")
+@Tag(name = "token API", description = "토큰 관련 API")
+public class TokenController {
+
+	private final TokenService tokenService;
+
+	/**
+	 * 토큰 재발급 요청 처리
+	 * Refresh 토큰과 장치 ID를 사용하여 새로운 액세스 토큰 발급
+	 */
+	@Operation(
+		summary = "Token Refresh",
+		description = "Refresh 토큰과 장치 ID를 사용하여 새로운 액세스 토큰을 발급합니다.",
+		security = @SecurityRequirement(name = "bearer-key")
+	)
+	@PostMapping("/reissue")
+	public ResponseEntity<ApiResult<MemberTokenResponse>> refreshToken(@RequestBody TokenRefreshRequest request) {
+		MemberTokenResponse response = tokenService.refreshToken(request);
+		return ApiResponse.ok(response);
+	}
+}

--- a/src/main/java/com/traveljournal/domain/member/dto/MemberTokenResponse.java
+++ b/src/main/java/com/traveljournal/domain/member/dto/MemberTokenResponse.java
@@ -1,0 +1,11 @@
+package com.traveljournal.domain.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MemberTokenResponse(
+	Long memberId,
+	String email,
+	TokenInfo tokenInfo
+) {
+}

--- a/src/main/java/com/traveljournal/domain/member/dto/ReissueRequest.java
+++ b/src/main/java/com/traveljournal/domain/member/dto/ReissueRequest.java
@@ -2,7 +2,7 @@ package com.traveljournal.domain.member.dto;
 
 import jakarta.validation.constraints.NotEmpty;
 
-public record TokenRefreshRequest (
+public record ReissueRequest (
 	@NotEmpty(message = "갱신 토큰은 필수 값입니다.")
 	String refreshToken,
 	@NotEmpty(message = "기기 아이디는 필수 값입니다.")

--- a/src/main/java/com/traveljournal/domain/member/dto/ReissueResonse.java
+++ b/src/main/java/com/traveljournal/domain/member/dto/ReissueResonse.java
@@ -1,0 +1,20 @@
+package com.traveljournal.domain.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ReissueResonse(
+	Long memberId,
+	String email,
+	String refreshToken,
+	String deviceId
+) {
+	public static ReissueResonse of(MemberTokenResponse memberTokenResponse) {
+		return ReissueResonse.builder()
+			.memberId(memberTokenResponse.memberId())
+			.email(memberTokenResponse.email())
+			.refreshToken(memberTokenResponse.tokenInfo().refreshToken())
+			.deviceId(memberTokenResponse.tokenInfo().deviceId())
+			.build();
+	}
+}

--- a/src/main/java/com/traveljournal/domain/member/dto/TokenInfo.java
+++ b/src/main/java/com/traveljournal/domain/member/dto/TokenInfo.java
@@ -1,0 +1,18 @@
+package com.traveljournal.domain.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record TokenInfo(
+	String accessToken,
+	String refreshToken,
+	String deviceId
+) {
+	public static TokenInfo of(String accessToken, String refreshToken, String deviceId) {
+		return TokenInfo.builder()
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.deviceId(deviceId)
+			.build();
+	}
+}

--- a/src/main/java/com/traveljournal/domain/member/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/traveljournal/domain/member/dto/TokenRefreshRequest.java
@@ -1,0 +1,11 @@
+package com.traveljournal.domain.member.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record TokenRefreshRequest (
+	@NotEmpty(message = "갱신 토큰은 필수 값입니다.")
+	String refreshToken,
+	@NotEmpty(message = "기기 아이디는 필수 값입니다.")
+	String deviceId
+){
+}

--- a/src/main/java/com/traveljournal/domain/member/entity/Member.java
+++ b/src/main/java/com/traveljournal/domain/member/entity/Member.java
@@ -1,11 +1,6 @@
 package com.traveljournal.domain.member.entity;
 
 import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.Collections;
-
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -14,8 +9,10 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,8 +20,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member")
-public class Member implements UserDetails {
-
+public class Member {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -59,45 +55,45 @@ public class Member implements UserDetails {
 
 	private Boolean isFirstLogin = true;
 
-	public void updateNickname(String nickname) {
+	@PrePersist
+	public void prePersist() {
+		this.createAt = LocalDateTime.now();
+	}
+
+	@Builder
+	public Member(String email, String nickname, String profileImageUrl, LocalDateTime birthdate,
+		AccountScope accountScope, String phoneNumber, SocialProvider socialProvider) {
+		this.email = email;
 		this.nickname = nickname;
+		this.profileImageUrl = profileImageUrl;
+		this.birthdate = birthdate;
+		this.accountScope = accountScope != null ? accountScope : AccountScope.PUBLIC;
+		this.phoneNumber = phoneNumber;
+		this.socialProvider = socialProvider;
+		this.isDeleted = false;
+		this.isFirstLogin = true;
+	}
+
+	// 첫 로그인 상태 변경
+	public void completeFirstLogin(String nickname, AccountScope accountScope) {
 		this.isFirstLogin = false;
+		this.nickname = nickname;
+		this.accountScope = accountScope;
 	}
 
-	// UserDetails 메서드 구현
-	@Override
-	public Collection<? extends GrantedAuthority> getAuthorities() {
-		return Collections.singletonList(() -> "ROLE_USER");
+	// 회원 정보 업데이트
+	public void updateProfile(String nickname, String profileImageUrl,
+		LocalDateTime birthdate, AccountScope accountScope,
+		String phoneNumber) {
+		this.nickname = nickname;
+		this.profileImageUrl = profileImageUrl;
+		this.birthdate = birthdate;
+		this.accountScope = accountScope;
+		this.phoneNumber = phoneNumber;
 	}
 
-	@Override
-	public String getPassword() {
-		// Member 클래스에 비밀번호 필드가 없는 경우 아래를 수정해야 함
-		return null; // 필드가 없다면 null, 아니면 password 필드 추가 및 반환
-	}
-
-	@Override
-	public String getUsername() {
-		return this.email; // socialLoginId를 username으로 사용
-	}
-
-	@Override
-	public boolean isAccountNonExpired() {
-		return true; // 계정 만료 여부 (true = 만료되지 않음)
-	}
-
-	@Override
-	public boolean isAccountNonLocked() {
-		return true; // 계정 잠금 여부 (true = 잠금되지 않음)
-	}
-
-	@Override
-	public boolean isCredentialsNonExpired() {
-		return true; // 자격 증명 만료 여부 (true = 만료되지 않음)
-	}
-
-	@Override
-	public boolean isEnabled() {
-		return !isDeleted; // 계정 활성화 여부 (삭제된 계정은 비활성화)
+	// 회원 삭제 (soft delete)
+	public void delete() {
+		this.isDeleted = true;
 	}
 }

--- a/src/main/java/com/traveljournal/domain/member/entity/Token.java
+++ b/src/main/java/com/traveljournal/domain/member/entity/Token.java
@@ -1,0 +1,42 @@
+package com.traveljournal.domain.member.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Token {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@JoinColumn(name = "member_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Member member;
+
+	private String refreshToken;
+
+	private String deviceId;
+
+	@Builder
+	public Token(Member member, String refreshToken, String deviceId) {
+		this.member = member;
+		this.refreshToken = refreshToken;
+		this.deviceId = deviceId;
+	}
+
+	public void updateRefreshToken(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+}

--- a/src/main/java/com/traveljournal/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/traveljournal/domain/member/repository/MemberRepository.java
@@ -8,4 +8,5 @@ import com.traveljournal.domain.member.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByEmail(String email);
+
 }

--- a/src/main/java/com/traveljournal/domain/member/repository/TokenRepository.java
+++ b/src/main/java/com/traveljournal/domain/member/repository/TokenRepository.java
@@ -1,0 +1,15 @@
+package com.traveljournal.domain.member.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.traveljournal.domain.member.entity.Token;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+
+	Optional<Token> findByDeviceId(String deviceId);
+
+	Optional<Token> findByDeviceIdAndMemberId(String deviceId, Long memberId);
+
+}

--- a/src/main/java/com/traveljournal/domain/member/service/MemberService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/MemberService.java
@@ -42,8 +42,8 @@ public class MemberService {
 	 * 카카오 회원정보를 바탕으로 회원 조회 또는 생성
 	 */
 	@Transactional
-	public Member findOrCreateMember(KakaoMemberInfo memberInfo) {
-		String email = memberInfo.kakao_account().email();
+	public Member findOrCreateMember(KakaoMemberInfo kakaoMemberInfo) {
+		String email = kakaoMemberInfo.kakao_account().email();
 
 		// 이메일로 회원 조회
 		Optional<Member> existingMember = memberRepository.findByEmail(email);
@@ -56,8 +56,8 @@ public class MemberService {
 		// 새 회원 생성
 		Member newMember = Member.builder()
 			.email(email)
-			.nickname(memberInfo.kakao_account().profile().nickname())
-			.profileImageUrl(memberInfo.kakao_account().profile().profile_image_url())
+			.nickname(kakaoMemberInfo.kakao_account().profile().nickname())
+			.profileImageUrl(kakaoMemberInfo.kakao_account().profile().profile_image_url())
 			.accountScope(AccountScope.PUBLIC)
 			.socialProvider(SocialProvider.KAKAO)
 			.build();
@@ -69,9 +69,9 @@ public class MemberService {
 	 * 첫 로그인 완료 처리
 	 */
 	@Transactional
-	public void completeFirstLogin(Long memberId, FirstLoginRequest request) {
+	public void completeFirstLogin(Long memberId, FirstLoginRequest firstLoginRequest) {
 		Member member = findById(memberId);
-		member.completeFirstLogin(request.nickname(), request.accountScope());
+		member.completeFirstLogin(firstLoginRequest.nickname(), firstLoginRequest.accountScope());
 	}
 
 	/**

--- a/src/main/java/com/traveljournal/domain/member/service/MemberService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/MemberService.java
@@ -5,8 +5,13 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.traveljournal.domain.auth.dto.FirstLoginRequest;
+import com.traveljournal.domain.auth.dto.KakaoMemberInfo;
+import com.traveljournal.domain.member.entity.AccountScope;
 import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.entity.SocialProvider;
 import com.traveljournal.domain.member.repository.MemberRepository;
+import com.traveljournal.global.exception.ResourceNotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,9 +21,68 @@ public class MemberService {
 
 	private final MemberRepository memberRepository;
 
+	/**
+	 * 이메일로 회원 조회
+	 */
 	@Transactional(readOnly = true)
 	public Optional<Member> findByEmail(String email) {
 		return memberRepository.findByEmail(email);
 	}
-}
 
+	/**
+	 * ID로 회원 조회
+	 */
+	@Transactional(readOnly = true)
+	public Member findById(Long memberId) {
+		return memberRepository.findById(memberId)
+			.orElseThrow(() -> new ResourceNotFoundException("회원을 찾을 수 없습니다. ID: " + memberId));
+	}
+
+	/**
+	 * 카카오 회원정보를 바탕으로 회원 조회 또는 생성
+	 */
+	@Transactional
+	public Member findOrCreateMember(KakaoMemberInfo memberInfo) {
+		String email = memberInfo.kakao_account().email();
+
+		// 이메일로 회원 조회
+		Optional<Member> existingMember = memberRepository.findByEmail(email);
+
+		// 기존 회원이 있으면 반환
+		if (existingMember.isPresent()) {
+			return existingMember.get();
+		}
+
+		// 새 회원 생성
+		Member newMember = Member.builder()
+			.email(email)
+			.nickname(memberInfo.kakao_account().profile().nickname())
+			.profileImageUrl(memberInfo.kakao_account().profile().profile_image_url())
+			.accountScope(AccountScope.PUBLIC)
+			.socialProvider(SocialProvider.KAKAO)
+			.build();
+
+		return memberRepository.save(newMember);
+	}
+
+	/**
+	 * 첫 로그인 완료 처리
+	 */
+	@Transactional
+	public void completeFirstLogin(Long memberId, FirstLoginRequest request) {
+		Member member = findById(memberId);
+		member.completeFirstLogin(request.nickname(), request.accountScope());
+	}
+
+	/**
+	 * 회원 프로필 업데이트
+	 */
+	@Transactional
+	public Member updateProfile(Long memberId, String nickname, String profileImageUrl,
+		java.time.LocalDateTime birthdate, AccountScope accountScope,
+		String phoneNumber) {
+		Member member = findById(memberId);
+		member.updateProfile(nickname, profileImageUrl, birthdate, accountScope, phoneNumber);
+		return member;
+	}
+}

--- a/src/main/java/com/traveljournal/domain/member/service/TokenService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/TokenService.java
@@ -90,16 +90,16 @@ public class TokenService {
 	 * 4. 새 액세스 토큰 발급
 	 */
 	@Transactional
-	public MemberTokenResponse refreshToken(ReissueRequest request) {
+	public MemberTokenResponse refreshToken(ReissueRequest reissueRequest) {
 		// 리프레시 토큰 검증
-		JwtValidateStatus status = jwtTokenProvider.getTokenValidationStatus(request.refreshToken());
+		JwtValidateStatus status = jwtTokenProvider.getTokenValidationStatus(reissueRequest.refreshToken());
 		if (status != JwtValidateStatus.ACCEPTED) {
 			throw new UnauthorizedException("리프레시 토큰이 유효하지 않습니다.");
 		}
 
 		// 장치 ID로 토큰 정보 조회
-		String deviceId = request.deviceId();
-		String email = jwtTokenProvider.getEmail(request.refreshToken());
+		String deviceId = reissueRequest.deviceId();
+		String email = jwtTokenProvider.getEmail(reissueRequest.refreshToken());
 		Member member = memberService.findByEmail(email)
 			.orElseThrow(() -> new UnauthorizedException("존재하지 않는 회원입니다."));
 
@@ -108,7 +108,7 @@ public class TokenService {
 			.orElseThrow(() -> new UnauthorizedException("토큰 정보가 존재하지 않습니다."));
 
 		// 토큰 비교
-		if (!savedRefreshToken.equals(request.refreshToken())) {
+		if (!savedRefreshToken.equals(reissueRequest.refreshToken())) {
 			throw new UnauthorizedException("리프레시 토큰이 일치하지 않습니다.");
 		}
 
@@ -121,7 +121,7 @@ public class TokenService {
 			.tokenInfo(
 				TokenInfo.builder()
 					.accessToken(newAccessToken)
-					.refreshToken(request.refreshToken())
+					.refreshToken(reissueRequest.refreshToken())
 					.deviceId(deviceId)
 					.build()
 			)

--- a/src/main/java/com/traveljournal/domain/member/service/TokenService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/TokenService.java
@@ -1,0 +1,132 @@
+package com.traveljournal.domain.member.service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.traveljournal.domain.member.dto.MemberTokenResponse;
+import com.traveljournal.domain.member.dto.TokenInfo;
+import com.traveljournal.domain.member.dto.TokenRefreshRequest;
+import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.entity.Token;
+import com.traveljournal.domain.member.repository.TokenRepository;
+import com.traveljournal.global.data.JwtValidateStatus;
+import com.traveljournal.global.exception.UnauthorizedException;
+import com.traveljournal.global.security.jwt.JwtTokenProvider;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TokenService {
+
+	private final TokenRepository tokenRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final MemberService memberService;
+
+	/**
+	 * JWT 토큰 생성
+	 */
+	public TokenInfo createTokens(String email, String deviceId) {
+		// 장치 ID가 없으면 생성
+		log.info("deviceId: " + deviceId);
+		if (deviceId == null || deviceId.isBlank()) {
+			deviceId = UUID.randomUUID().toString();
+		}
+		log.info("deviceId: " + deviceId);
+		String accessToken = jwtTokenProvider.createAccessToken(email);
+		String refreshToken = jwtTokenProvider.createRefreshToken(email);
+		return TokenInfo.of(accessToken, refreshToken, deviceId);
+	}
+
+	/**
+	 * 회원과 장치 ID로 토큰 저장 또는 업데이트
+	 */
+	@Transactional
+	public void saveOrUpdateToken(Member member, String deviceId, String refreshToken) {
+		// 기존 토큰이 있는지 확인
+		Optional<Token> existingToken = tokenRepository.findByDeviceId(deviceId);
+
+		if (existingToken.isPresent()) {
+			// 기존 토큰 업데이트
+			Token token = existingToken.get();
+			token.updateRefreshToken(refreshToken);
+		} else {
+			// 새 토큰 생성
+			Token token = Token.builder()
+				.member(member)
+				.refreshToken(refreshToken)
+				.deviceId(deviceId)
+				.build();
+			tokenRepository.save(token);
+		}
+	}
+
+	/**
+	 * 장치 ID로 리프레시 토큰 조회
+	 */
+	@Transactional(readOnly = true)
+	public Optional<String> getRefreshTokenByDeviceId(String deviceId) {
+		return tokenRepository.findByDeviceId(deviceId)
+			.map(Token::getRefreshToken);
+	}
+
+	/**
+	 * 회원 ID와 장치 ID로 토큰 삭제 (로그아웃)
+	 */
+	@Transactional
+	public void deleteToken(Long memberId, String deviceId) {
+		tokenRepository.findByDeviceIdAndMemberId(deviceId, memberId)
+			.ifPresent(tokenRepository::delete);
+	}
+
+	/**
+	 * 토큰 재발급
+	 * 1. 리프레시 토큰 검증
+	 * 2. 장치 ID로 토큰 정보 조회
+	 * 3. 저장된 리프레시 토큰과 요청된 리프레시 토큰 비교
+	 * 4. 새 액세스 토큰 발급
+	 */
+	@Transactional
+	public MemberTokenResponse refreshToken(TokenRefreshRequest request) {
+		// 리프레시 토큰 검증
+		JwtValidateStatus status = jwtTokenProvider.getTokenValidationStatus(request.refreshToken());
+		if (status != JwtValidateStatus.ACCEPTED) {
+			throw new UnauthorizedException("리프레시 토큰이 유효하지 않습니다.");
+		}
+
+		// 장치 ID로 토큰 정보 조회
+		String deviceId = request.deviceId();
+		String email = jwtTokenProvider.getEmail(request.refreshToken());
+		Member member = memberService.findByEmail(email)
+			.orElseThrow(() -> new UnauthorizedException("존재하지 않는 회원입니다."));
+
+		// 저장된 토큰 조회
+		String savedRefreshToken = getRefreshTokenByDeviceId(deviceId)
+			.orElseThrow(() -> new UnauthorizedException("토큰 정보가 존재하지 않습니다."));
+
+		// 토큰 비교
+		if (!savedRefreshToken.equals(request.refreshToken())) {
+			throw new UnauthorizedException("리프레시 토큰이 일치하지 않습니다.");
+		}
+
+		// 새 액세스 토큰 발급
+		String newAccessToken = jwtTokenProvider.createAccessToken(email);
+
+		return MemberTokenResponse.builder()
+			.memberId(member.getId())
+			.email(member.getEmail())
+			.tokenInfo(
+				TokenInfo.builder()
+					.accessToken(newAccessToken)
+					.refreshToken(request.refreshToken())
+					.deviceId(deviceId)
+					.build()
+			)
+			.build();
+	}
+}

--- a/src/main/java/com/traveljournal/domain/member/service/TokenService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/TokenService.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.traveljournal.domain.member.dto.MemberTokenResponse;
+import com.traveljournal.domain.member.dto.ReissueRequest;
 import com.traveljournal.domain.member.dto.TokenInfo;
-import com.traveljournal.domain.member.dto.TokenRefreshRequest;
 import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.member.entity.Token;
 import com.traveljournal.domain.member.repository.TokenRepository;
@@ -33,11 +33,9 @@ public class TokenService {
 	 */
 	public TokenInfo createTokens(String email, String deviceId) {
 		// 장치 ID가 없으면 생성
-		log.info("deviceId: " + deviceId);
 		if (deviceId == null || deviceId.isBlank()) {
 			deviceId = UUID.randomUUID().toString();
 		}
-		log.info("deviceId: " + deviceId);
 		String accessToken = jwtTokenProvider.createAccessToken(email);
 		String refreshToken = jwtTokenProvider.createRefreshToken(email);
 		return TokenInfo.of(accessToken, refreshToken, deviceId);
@@ -92,7 +90,7 @@ public class TokenService {
 	 * 4. 새 액세스 토큰 발급
 	 */
 	@Transactional
-	public MemberTokenResponse refreshToken(TokenRefreshRequest request) {
+	public MemberTokenResponse refreshToken(ReissueRequest request) {
 		// 리프레시 토큰 검증
 		JwtValidateStatus status = jwtTokenProvider.getTokenValidationStatus(request.refreshToken());
 		if (status != JwtValidateStatus.ACCEPTED) {

--- a/src/main/java/com/traveljournal/global/config/KakaoOAuthConfig.java
+++ b/src/main/java/com/traveljournal/global/config/KakaoOAuthConfig.java
@@ -1,0 +1,19 @@
+package com.traveljournal.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "oauth.kakao")
+public class KakaoOAuthConfig {
+	private String clientId;
+	private String clientSecret;
+	private String redirectUri;
+	private String tokenUri;
+	private String userInfoUri;
+}

--- a/src/main/java/com/traveljournal/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/traveljournal/global/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.traveljournal.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/src/main/java/com/traveljournal/global/config/SecurityConfig.java
+++ b/src/main/java/com/traveljournal/global/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
 				requests.requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**",
 						"/v3/api-docs/**").permitAll()
 					.requestMatchers(HttpMethod.GET,"/v1/auth/kakao/callback").permitAll()
+					.requestMatchers(HttpMethod.POST,"/v1/auth/kakao/id-token-login").permitAll()
 					.requestMatchers(HttpMethod.POST, "/v1/tokens/reissue").permitAll()
 					.anyRequest().authenticated()
 			)

--- a/src/main/java/com/traveljournal/global/config/SecurityConfig.java
+++ b/src/main/java/com/traveljournal/global/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(requests ->
 				requests.requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**",
 						"/v3/api-docs/**").permitAll()
+					.requestMatchers("/auth/kakao/**", "/auth/login", "/auth/signup").permitAll()
 					.anyRequest().authenticated()
 			)
 			.sessionManagement(sessionManagement ->

--- a/src/main/java/com/traveljournal/global/config/SecurityConfig.java
+++ b/src/main/java/com/traveljournal/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -47,7 +48,8 @@ public class SecurityConfig {
 			.authorizeHttpRequests(requests ->
 				requests.requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**",
 						"/v3/api-docs/**").permitAll()
-					.requestMatchers("/auth/kakao/**", "/auth/login", "/auth/signup").permitAll()
+					.requestMatchers(HttpMethod.GET,"/v1/auth/kakao/callback").permitAll()
+					.requestMatchers(HttpMethod.POST, "/v1/tokens/reissue").permitAll()
 					.anyRequest().authenticated()
 			)
 			.sessionManagement(sessionManagement ->

--- a/src/main/java/com/traveljournal/global/data/ApiResponse.java
+++ b/src/main/java/com/traveljournal/global/data/ApiResponse.java
@@ -1,35 +1,55 @@
 package com.traveljournal.global.data;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-public class ApiResponse<T> extends ResponseEntity<T> {
+public class ApiResponse {
 
-	public ApiResponse(HttpStatus status) {
-		super(status);
+	/**
+	 * 일반 성공 응답
+	 */
+	public static <T> ResponseEntity<ApiResult<T>> ok(T data) {
+		ApiResult<T> result = ApiResult.<T>builder()
+			.success(true)
+			.message("요청이 성공적으로 처리되었습니다.")
+			.data(data)
+			.build();
+		return ResponseEntity.ok(result);
 	}
 
-	public static <LoginResponse> ResponseEntity<LoginResponse> accessTokenResponse(LoginResponse loginResponse,
-		String accessToken) {
+	/**
+	 * 생성 성공 응답
+	 */
+	public static <T> ResponseEntity<ApiResult<T>> created(T data) {
+		ApiResult<T> result = ApiResult.<T>builder()
+			.success(true)
+			.message("데이터가 성공적으로 생성되었습니다.")
+			.data(data)
+			.build();
+		return ResponseEntity.status(HttpStatus.CREATED).body(result);
+	}
+
+	/**
+	 * 성공 응답 (수정, 삭제)
+	 */
+	public static ResponseEntity<ApiResult<Void>> success(String message) {
+		ApiResult<Void> result = ApiResult.<Void>builder()
+			.success(true)
+			.message(message)
+			.build();
+		return ResponseEntity.ok(result);
+	}
+
+	/**
+	 * 액세스 토큰을 헤더에 포함하는 응답
+	 */
+	public static <T> ResponseEntity<T> accessTokenResponse(T data, String accessToken) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", "Bearer " + accessToken);
+
 		return ResponseEntity.ok()
-			.header("Authorization", "Bearer " + accessToken)
-			.body(loginResponse);
+			.headers(headers)
+			.body(data);
 	}
-
-	public static ResponseEntity<?> createdSuccess(String message) {
-		return ResponseEntity.status(HttpStatus.CREATED).body(message);
-	}
-
-	public static ResponseEntity<?> deletedSuccess(String message) {
-		return ResponseEntity.ok(message);
-	}
-
-	public static ResponseEntity<?> updatedSuccess(String message) {
-		return ResponseEntity.ok(message);
-	}
-
-	public static <T> ResponseEntity<T> getObjectSuccess(T object) {
-		return ResponseEntity.ok(object);
-	}
-
 }

--- a/src/main/java/com/traveljournal/global/data/ApiResult.java
+++ b/src/main/java/com/traveljournal/global/data/ApiResult.java
@@ -1,0 +1,16 @@
+package com.traveljournal.global.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResult<T> {
+	private boolean success;
+	private String message;
+	private T data;
+}

--- a/src/main/java/com/traveljournal/global/data/JwtValidateStatus.java
+++ b/src/main/java/com/traveljournal/global/data/JwtValidateStatus.java
@@ -1,0 +1,7 @@
+package com.traveljournal.global.data;
+
+public enum JwtValidateStatus {
+	ACCEPTED,
+	EXPIRED,
+	DENIED
+}

--- a/src/main/java/com/traveljournal/global/exception/ExternalApiException.java
+++ b/src/main/java/com/traveljournal/global/exception/ExternalApiException.java
@@ -1,0 +1,16 @@
+package com.traveljournal.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+public class ExternalApiException extends RuntimeException {
+
+	public ExternalApiException(String message) {
+		super(message);
+	}
+
+	public ExternalApiException() {
+		super("외부 API 호출에 실패했습니다.");
+	}
+}

--- a/src/main/java/com/traveljournal/global/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/traveljournal/global/exception/ResourceNotFoundException.java
@@ -1,0 +1,16 @@
+package com.traveljournal.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+
+	public ResourceNotFoundException(String message) {
+		super(message);
+	}
+
+	public ResourceNotFoundException() {
+		super("요청한 리소스를 찾을 수 없습니다.");
+	}
+}

--- a/src/main/java/com/traveljournal/global/exception/UnauthorizedException.java
+++ b/src/main/java/com/traveljournal/global/exception/UnauthorizedException.java
@@ -1,0 +1,17 @@
+package com.traveljournal.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class UnauthorizedException extends RuntimeException {
+
+	public UnauthorizedException(String message) {
+		super(message);
+	}
+
+	public UnauthorizedException() {
+		super("인증에 실패했습니다.");
+	}
+}
+

--- a/src/main/java/com/traveljournal/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/traveljournal/global/security/jwt/JwtAuthenticationFilter.java
@@ -2,8 +2,10 @@ package com.traveljournal.global.security.jwt;
 
 import java.io.IOException;
 
-import org.springframework.stereotype.Component;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.traveljournal.global.data.JwtValidateStatus;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -17,21 +19,42 @@ import lombok.extern.slf4j.Slf4j;
  * 요청이 올 때마다 실행되며, JWT 토큰을 검증하고 인증 정보를 설정한다.
  */
 @Slf4j
-@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;
 
 	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-		throws ServletException, IOException {
-		String token = jwtTokenProvider.resolveToken(request.getHeader("Authorization"));
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
 
-		if (token != null && jwtTokenProvider.validateToken(token)) {
-			jwtTokenProvider.setAuthentication(token);
-		} else {
-			log.warn("Invalid or missing JWT token");
+		// 헤더에서 Authorization 값 추출
+		String authorization = request.getHeader("Authorization");
+
+		// 토큰이 있는 경우에만 처리
+		if (authorization != null) {
+			// Bearer 토큰 추출
+			String token = jwtTokenProvider.resolveToken(authorization);
+
+			if (token != null) {
+				// 토큰 유효성 검사
+				JwtValidateStatus status = jwtTokenProvider.getTokenValidationStatus(token);
+
+				if (status == JwtValidateStatus.ACCEPTED) {
+					try {
+						// 인증 정보 설정
+						jwtTokenProvider.setAuthentication(token);
+						log.debug("토큰 인증 성공");
+					} catch (Exception e) {
+						log.error("토큰 처리 중 에러 발생: {}", e.getMessage());
+						SecurityContextHolder.clearContext();
+					}
+				} else {
+					log.debug("유효하지 않은 토큰: {}", status);
+				}
+			}
 		}
 
 		filterChain.doFilter(request, response);

--- a/src/main/java/com/traveljournal/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/traveljournal/global/security/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.traveljournal.global.security.jwt;
 import java.io.IOException;
 
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.traveljournal.global.data.JwtValidateStatus;
@@ -20,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @RequiredArgsConstructor
+@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/traveljournal/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/traveljournal/global/security/jwt/JwtTokenProvider.java
@@ -9,23 +9,20 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import com.traveljournal.global.config.AppConfig;
+import com.traveljournal.global.data.JwtValidateStatus;
+import com.traveljournal.global.security.service.CustomUserDetailsService;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-/**
- * JWT 토큰을 관리하는 클래스
- * - 토큰 생성, 검증, 파싱 기능을 수행한다.
- */
 
 /**
  * JWT 토큰을 관리하는 클래스
@@ -34,10 +31,13 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtTokenProvider {
 
-	private final SecretKey secretKey;
-	private final UserDetailsService userDetailsService;
+	private final AppConfig appConfig;
+	private final CustomUserDetailsService userDetailsService;
+
+	private SecretKey secretKey;
 
 	@Value("${jwt.access-token-expiration}")
 	private long accessTokenExpiration; // Access Token 유효 기간
@@ -45,11 +45,9 @@ public class JwtTokenProvider {
 	@Value("${jwt.refresh-token-expiration}")
 	private long refreshTokenExpiration; // Refresh Token 유효 기간
 
-	public JwtTokenProvider(AppConfig appConfig, UserDetailsService userDetailsService) {
-		// Base64로 디코딩한 secretKey를 생성
-		this.secretKey = Keys.hmacShaKeyFor(appConfig.getSecretKey()); // 추가 디코딩 제거
-
-		this.userDetailsService = userDetailsService;
+	@PostConstruct
+	public void init() {
+		this.secretKey = Keys.hmacShaKeyFor(appConfig.getSecretKey());
 	}
 
 	/**
@@ -82,35 +80,58 @@ public class JwtTokenProvider {
 	}
 
 	/**
-	 * JWT 토큰에서 email 추출
+	 * JWT 토큰에서 이메일 추출
 	 */
 	public String getEmail(String token) {
-		return parseClaims(token).getBody().getSubject();
+		try {
+			return Jwts.parserBuilder()
+				.setSigningKey(secretKey)
+				.build()
+				.parseClaimsJws(token)
+				.getBody()
+				.getSubject();
+		} catch (ExpiredJwtException e) {
+			// 만료된 토큰이라도 이메일은 추출
+			return e.getClaims().getSubject();
+		}
 	}
 
 	/**
-	 * JWT 토큰 검증
+	 * 토큰 검증을 위한 메서드
+	 * @param token 접근 토큰 혹은 갱신 토큰
+	 * @return JwtValidateStatus
+	 *  ACCEPTED 검증 완료
+	 *  EXPIRED 만료
+	 *  DENIED 검증 실패
 	 */
-	public boolean validateToken(String token) {
+	public JwtValidateStatus getTokenValidationStatus(String token) {
 		try {
-			parseClaims(token);
-			return true;
+			Jwts.parserBuilder()
+				.setSigningKey(secretKey)
+				.build()
+				.parseClaimsJws(token);
+			return JwtValidateStatus.ACCEPTED;
 		} catch (ExpiredJwtException e) {
-			log.warn("Expired JWT Token: {}", e.getMessage());
+			return JwtValidateStatus.EXPIRED;
 		} catch (JwtException e) {
-			log.warn("Invalid JWT Token: {}", e.getMessage());
+			return JwtValidateStatus.DENIED;
 		}
-		return false;
 	}
 
 	/**
 	 * JWT 토큰에서 Claims 추출
 	 */
-	private Jws<Claims> parseClaims(String token) {
-		return Jwts.parserBuilder()
-			.setSigningKey(secretKey)
-			.build()
-			.parseClaimsJws(token);
+	public Claims getClaims(String token) {
+		try {
+			return Jwts.parserBuilder()
+				.setSigningKey(secretKey)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+		} catch (ExpiredJwtException e) {
+			// 만료된 토큰이라도 Claims 반환
+			return e.getClaims();
+		}
 	}
 
 	/**
@@ -128,12 +149,11 @@ public class JwtTokenProvider {
 	 */
 	public void setAuthentication(String token) {
 		String email = getEmail(token);
-
-		// userDetailsService를 통해 UserDetails 로드
 		UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-		Authentication authentication =
-			new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+		Authentication authentication = new UsernamePasswordAuthenticationToken(
+			userDetails, null, userDetails.getAuthorities());
+
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 	}
-
 }

--- a/src/main/java/com/traveljournal/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/traveljournal/global/security/jwt/JwtTokenProvider.java
@@ -138,10 +138,17 @@ public class JwtTokenProvider {
 	 * 요청 헤더에서 JWT 토큰 추출
 	 */
 	public String resolveToken(String bearerToken) {
-		if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+		validateAuthorizationHeader(bearerToken);
+		if (bearerToken.startsWith("Bearer ")) {
 			return bearerToken.substring(7);
 		}
 		return null;
+	}
+
+	private void validateAuthorizationHeader(String authorizationHeader) {
+		if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+			throw new IllegalArgumentException("유효한 Authorization 헤더가 필요합니다.");
+		}
 	}
 
 	/**

--- a/src/main/java/com/traveljournal/global/security/service/CustomUserDetails.java
+++ b/src/main/java/com/traveljournal/global/security/service/CustomUserDetails.java
@@ -1,0 +1,64 @@
+package com.traveljournal.global.security.service;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.traveljournal.domain.member.entity.Member;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Spring Security에서 사용할 CustomUserDetails
+ */
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+	private final Long memberId;  // 추가
+	private final String email;
+	private final Collection<? extends GrantedAuthority> authorities;
+
+	public CustomUserDetails(Member member) {
+		this.memberId = member.getId();
+		this.email = member.getEmail();
+		this.authorities = Collections.singletonList(() -> "ROLE_USER"); // 기본 권한 설정
+	}
+
+	@Override
+	public String getUsername() {
+		return email;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
+	}
+
+	@Override
+	public String getPassword() {
+		return ""; // OAuth2 로그인 시 비밀번호 사용 안 함
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/com/traveljournal/global/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/traveljournal/global/security/service/CustomUserDetailsService.java
@@ -4,7 +4,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -12,14 +14,19 @@ import lombok.RequiredArgsConstructor;
 /**
  * 사용자 정보를 로드하는 서비스
  */
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
+
 	private final MemberRepository memberRepository;
 
 	@Override
+	@Transactional(readOnly = true)
 	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-		return memberRepository.findByEmail(email)
-			.orElseThrow(() -> new UsernameNotFoundException("User not found: " + email));
+		Member member = memberRepository.findByEmail(email)
+			.orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+
+		// CustomUserDetails 반환
+		return new CustomUserDetails(member);
 	}
 }

--- a/src/main/java/com/traveljournal/global/security/util/SecurityUtil.java
+++ b/src/main/java/com/traveljournal/global/security/util/SecurityUtil.java
@@ -1,0 +1,26 @@
+package com.traveljournal.global.security.util;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.traveljournal.global.security.service.CustomUserDetails;
+
+/**
+ * 현재 로그인한 사용자의 정보를 가져오는 유틸 클래스
+ */
+public class SecurityUtil {
+
+	/**
+	 * 현재 로그인한 사용자의 memberId 가져오기
+	 * @return Long memberId
+	 * @throws IllegalStateException 로그인 정보가 없거나 잘못된 경우
+	 */
+	public static Long getCurrentMemberId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {
+			throw new IllegalStateException("올바른 사용자 정보가 아닙니다.");
+		}
+		return userDetails.getMemberId();
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,5 +5,11 @@ spring:
     password: ${secret.dev-password}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+oauth:
+  kakao:
+    redirect-uri: http://localhost:8080/auth/kakao/callback
+    token-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+
 springdoc:
   request-url: ${secret.dev-request-url}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,11 +5,9 @@ spring:
     password: ${secret.dev-password}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-oauth:
-  kakao:
-    redirect-uri: http://localhost:8080/auth/kakao/callback
-    token-uri: https://kauth.kakao.com/oauth/token
-    user-info-uri: https://kapi.kakao.com/v2/user/me
-
 springdoc:
   request-url: ${secret.dev-request-url}
+
+oauth:
+  kakao:
+    redirect-uri: ${oauth.kakao.dev-redirect-uri}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,15 +1,13 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/traveljournal_db
+    url: jdbc:mysql://mysql:3306/traveljournal_db
     username: app_user
     password: ${secret.prod-password}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
 oauth:
   kakao:
-    redirect-uri: http://localhost:8080/auth/kakao/callback
-    token-uri: https://kauth.kakao.com/oauth/token
-    user-info-uri: https://kapi.kakao.com/v2/user/me
+    redirect-uri: ${oauth.kakao.prod-redirect-uri}
 
 springdoc:
   request-url: ${secret.prod-request-url}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,5 +5,11 @@ spring:
     password: ${secret.prod-password}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+oauth:
+  kakao:
+    redirect-uri: http://localhost:8080/auth/kakao/callback
+    token-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+
 springdoc:
   request-url: ${secret.prod-request-url}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/traveljournal_db
+    username: root
+    password: ${secret.prod-password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+springdoc:
+  request-url: ${secret.prod-request-url}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     url: jdbc:mysql://localhost:3306/traveljournal_db
-    username: root
+    username: app_user
     password: ${secret.prod-password}
     driver-class-name: com.mysql.cj.jdbc.Driver
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: dev
+    active: prod
     include: secret
   jpa:
     hibernate:


### PR DESCRIPTION
## 🔥 해결된 이슈
- Closes #7 

## 📌 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련된 테스트를 추가하거나 기존 테스트를 실행하여 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드를 따랐는지 확인했습니다.
- [x] 배포가 필요한 경우 관련 작업을 완료했습니다. (예: CI/CD 설정, 환경 변수 추가 등)

## ✨ 작업 내용
- [x] Member Entity에서 userDetails 삭제
> 따로 분리하여 구현
- [x] jwt token 전체 수정
> 액세스 토큰, 리프레쉬 토큰, 디바이스 아이디 설정완료
- [x] 카카오 로그인 구현
> 인가코드 혹은 id Token으로 카카오 로그인 가능합니다.
로그아웃 시 특정 장치의 토큰을 삭제합니다.
- [x] 첫 로그인시 업데이트 기능 구현
> isFirstLogin = true 일 경우 첫 로그인이라는 뜻으로 프론트에서 감지 후 데이터 수정
- [x] appConfig 기능 변경
> 확장성을 위해 메서드 단위가 아닌 클래스 단위로 변경
- [x] refresh Token을 통한 access Token 재발급 기능 구현
> deviceId와 refreshToken으로 새로운 accessToken발급 가능

## 🚀 추가 설명
> 전체적인 Member, Token 전부 건드렸습니다.
모든 부분 테스트 완료 하였으며, 카카오 로그인은 비동기로 처리하려하였으나 시도하다가 실패하였습니다.
idToken을 통해 보다 안전하게 회원정보를 불러오고 있으니 참고바랍니다.

현재 예외사항 처리는 리팩토링 과정에서 진행할 예정입니다.

## 📸 테스트 결과 (스크린샷 혹은 로그)
> 
![image](https://github.com/user-attachments/assets/3cf3ebdd-5ea1-4cdc-ba79-ee3573cee519)
![image](https://github.com/user-attachments/assets/cef01e05-e8b4-4785-8778-ca97d77ef43d)
![image](https://github.com/user-attachments/assets/39096575-883f-4bcc-b807-ef1fbfa1a929)
![image](https://github.com/user-attachments/assets/e9ef5143-94d7-4adf-9f89-cde83b610427)
![image](https://github.com/user-attachments/assets/ea5ebcb8-858f-46f9-8447-1a661bd50f7f)
![image](https://github.com/user-attachments/assets/1b8c273c-bf61-4667-8a0a-a7e0ed8ba641)