### PR TITLE
TJFE-61 [Feature] 소셜로그인(Apple) 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0'
+
+    // Commons IO - openfeign 취약점 해결
+    implementation 'commons-io:commons-io:2.14.0'
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/traveljournal/TravelJournalApplication.java
+++ b/src/main/java/com/traveljournal/TravelJournalApplication.java
@@ -2,7 +2,9 @@ package com.traveljournal;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class TravelJournalApplication {
 

--- a/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
@@ -14,7 +14,7 @@ import com.traveljournal.domain.auth.dto.LoginResponse;
 import com.traveljournal.domain.auth.service.AuthService;
 import com.traveljournal.domain.auth.util.EnumUtils;
 import com.traveljournal.domain.member.entity.SocialProvider;
-import com.traveljournal.global.data.ApiResponse;
+import com.traveljournal.global.data.ResponseHandler;
 import com.traveljournal.global.security.util.SecurityUtil;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,7 +49,7 @@ public class AuthController {
 		@Parameter(description = "디바이스 ID (선택 사항)")
 		@RequestParam(required = false) String deviceId,
 
-		@Parameter(description = "소셜로그인 제공자")
+		@Parameter(description = "소셜로그인 제공자 (kakao, google, apple)")
 		@PathVariable String socialProvider,
 
 		@Parameter(description = "플랫폼 (web, ios, android)")
@@ -59,7 +59,7 @@ public class AuthController {
 
 		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithCode(socialProviderEnum,code, deviceId, platform);
 
-		return ApiResponse.accessTokenResponse(loginCombinedResponse.LoginResponse(), loginCombinedResponse.accessToken());
+		return ResponseHandler.accessTokenResponse(loginCombinedResponse.LoginResponse(), loginCombinedResponse.accessToken());
 	}
 
 	@Operation(
@@ -76,7 +76,7 @@ public class AuthController {
 		@Parameter(description = "디바이스 ID (선택 사항)")
 		@RequestParam(required = false) String deviceId,
 
-		@Parameter(description = "소셜로그인 제공자", example = "kakao, google, apple 셋 중 하나")
+		@Parameter(description = "소셜로그인 제공자 (kakao, google, apple)")
 		@PathVariable String socialProvider,
 
 		@Parameter(description = "플랫폼 (web, ios, android)")
@@ -86,7 +86,7 @@ public class AuthController {
 
 		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithIdToken(socialProviderEnum, authorizationHeader, deviceId, platform);
 
-		return ApiResponse.accessTokenResponse(loginCombinedResponse.LoginResponse(), loginCombinedResponse.accessToken());
+		return ResponseHandler.accessTokenResponse(loginCombinedResponse.LoginResponse(), loginCombinedResponse.accessToken());
 	}
 
 	/**
@@ -105,6 +105,6 @@ public class AuthController {
 		Long memberId = SecurityUtil.getCurrentMemberId();
 
 		authService.logout(memberId, deviceId);
-		return ApiResponse.success("로그아웃되었습니다.");
+		return ResponseHandler.success("로그아웃되었습니다.");
 	}
 }

--- a/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
@@ -50,18 +50,23 @@ public class AuthController {
 		@RequestParam(required = false) String deviceId,
 
 		@Parameter(description = "소셜로그인 제공자")
-		@PathVariable String socialProvider
+		@PathVariable String socialProvider,
+
+		@Parameter(description = "플랫폼 (web, ios, android)")
+		@RequestHeader(value = "X-Platform", defaultValue = "web") String platform
 	) {
 		SocialProvider socialProviderEnum = EnumUtils.toSocialProvider(socialProvider);
 
-		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithCode(socialProviderEnum,code, deviceId);
+		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithCode(socialProviderEnum,code, deviceId, platform);
 
 		return ApiResponse.accessTokenResponse(loginCombinedResponse.LoginResponse(), loginCombinedResponse.accessToken());
 	}
 
 	@Operation(
-		summary = "Kakao ID Token Login",
-		description = "카카오 ID 토큰을 이용한 로그인. Bearer 토큰을 Authorization 헤더에 포함해야 합니다."
+		summary = "Social ID Token Login",
+		description = """
+			ID 토큰을 이용한 로그인. Bearer 토큰을 Authorization 헤더에 포함해야 합니다.
+			<br> X-Platform 헤더에 (web, ios, android)를 포함해야 합니다."""
 	)
 	@PostMapping("/login/{socialProvider}/id-token")
 	public ResponseEntity<LoginResponse> kakaoLoginWithIdToken(
@@ -72,11 +77,14 @@ public class AuthController {
 		@RequestParam(required = false) String deviceId,
 
 		@Parameter(description = "소셜로그인 제공자", example = "kakao, google, apple 셋 중 하나")
-		@PathVariable String socialProvider
+		@PathVariable String socialProvider,
+
+		@Parameter(description = "플랫폼 (web, ios, android)")
+		@RequestHeader(value = "X-Platform", defaultValue = "web") String platform
 	) {
 		SocialProvider socialProviderEnum = EnumUtils.toSocialProvider(socialProvider);
 
-		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithIdToken(socialProviderEnum, authorizationHeader, deviceId);
+		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithIdToken(socialProviderEnum, authorizationHeader, deviceId, platform);
 
 		return ApiResponse.accessTokenResponse(loginCombinedResponse.LoginResponse(), loginCombinedResponse.accessToken());
 	}

--- a/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
@@ -19,6 +19,7 @@ import com.traveljournal.global.security.util.SecurityUtil;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -57,9 +58,11 @@ public class AuthController {
 	) {
 		SocialProvider socialProviderEnum = EnumUtils.toSocialProvider(socialProvider);
 
-		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithCode(socialProviderEnum,code, deviceId, platform);
+		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithCode(socialProviderEnum, code,
+			deviceId, platform);
 
-		return ResponseHandler.accessTokenResponse(loginCombinedResponse.LoginResponse(), loginCombinedResponse.accessToken());
+		return ResponseHandler.accessTokenResponse(loginCombinedResponse.LoginResponse(),
+			loginCombinedResponse.accessToken());
 	}
 
 	@Operation(
@@ -84,9 +87,11 @@ public class AuthController {
 	) {
 		SocialProvider socialProviderEnum = EnumUtils.toSocialProvider(socialProvider);
 
-		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithIdToken(socialProviderEnum, authorizationHeader, deviceId, platform);
+		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithIdToken(socialProviderEnum,
+			authorizationHeader, deviceId, platform);
 
-		return ResponseHandler.accessTokenResponse(loginCombinedResponse.LoginResponse(), loginCombinedResponse.accessToken());
+		return ResponseHandler.accessTokenResponse(loginCombinedResponse.LoginResponse(),
+			loginCombinedResponse.accessToken());
 	}
 
 	/**
@@ -96,7 +101,10 @@ public class AuthController {
 	@Operation(
 		summary = "Logout",
 		description = "특정 장치에서 로그아웃을 처리하고 해당 장치의 토큰을 삭제합니다.",
-		security = @SecurityRequirement(name = "bearer-key")
+		security = @SecurityRequirement(name = "bearer-key"),
+		responses = {
+			@ApiResponse(responseCode = "200", ref = "#/components/responses/Logout"),
+		}
 	)
 	@PostMapping("/logout")
 	public ResponseEntity<?> logout(
@@ -105,6 +113,6 @@ public class AuthController {
 		Long memberId = SecurityUtil.getCurrentMemberId();
 
 		authService.logout(memberId, deviceId);
-		return ResponseHandler.success("로그아웃되었습니다.");
+		return ResponseHandler.success("로그아웃 성공");
 	}
 }

--- a/src/main/java/com/traveljournal/domain/auth/dto/SocialMemberInfo.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/SocialMemberInfo.java
@@ -1,0 +1,7 @@
+package com.traveljournal.domain.auth.dto;
+
+public interface SocialMemberInfo {
+	String getId();
+	String getEmail();
+	String getProfileImageUrl();
+}

--- a/src/main/java/com/traveljournal/domain/auth/dto/apple/AppleIdTokenInfo.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/apple/AppleIdTokenInfo.java
@@ -1,0 +1,7 @@
+package com.traveljournal.domain.auth.dto.apple;
+
+public record AppleIdTokenInfo(
+	String sub,
+	String email,
+	boolean emailVerified
+) {}

--- a/src/main/java/com/traveljournal/domain/auth/dto/apple/AppleKeyInfo.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/apple/AppleKeyInfo.java
@@ -1,0 +1,10 @@
+package com.traveljournal.domain.auth.dto.apple;
+
+public record AppleKeyInfo(
+	String kty,
+	String kid,
+	String use,
+	String alg,
+	String n,
+	String e
+) {}

--- a/src/main/java/com/traveljournal/domain/auth/dto/apple/AppleMemberInfo.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/apple/AppleMemberInfo.java
@@ -1,0 +1,24 @@
+package com.traveljournal.domain.auth.dto.apple;
+
+import com.traveljournal.domain.auth.dto.SocialMemberInfo;
+
+public record AppleMemberInfo(
+	String id,
+	String email,
+	String profileImageUrl
+) implements SocialMemberInfo {
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public String getEmail() {
+		return email;
+	}
+
+	@Override
+	public String getProfileImageUrl() {
+		return profileImageUrl;
+	}
+}

--- a/src/main/java/com/traveljournal/domain/auth/dto/apple/ApplePublicKeyResponse.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/apple/ApplePublicKeyResponse.java
@@ -1,0 +1,7 @@
+package com.traveljournal.domain.auth.dto.apple;
+
+import java.util.List;
+
+public record ApplePublicKeyResponse(
+	List<AppleKeyInfo> keys
+) {}

--- a/src/main/java/com/traveljournal/domain/auth/dto/apple/AppleTokenResponse.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/apple/AppleTokenResponse.java
@@ -1,0 +1,11 @@
+package com.traveljournal.domain.auth.dto.apple;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AppleTokenResponse(
+	@JsonProperty("access_token") String accessToken,
+	@JsonProperty("token_type") String tokenType,
+	@JsonProperty("expires_in") Long expiresIn,
+	@JsonProperty("refresh_token") String refreshToken,
+	@JsonProperty("id_token") String idToken
+) {}

--- a/src/main/java/com/traveljournal/domain/auth/dto/kakao/KakaoIdTokenInfo.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/kakao/KakaoIdTokenInfo.java
@@ -1,4 +1,4 @@
-package com.traveljournal.domain.auth.dto;
+package com.traveljournal.domain.auth.dto.kakao;
 
 import lombok.Builder;
 

--- a/src/main/java/com/traveljournal/domain/auth/dto/kakao/KakaoMemberInfo.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/kakao/KakaoMemberInfo.java
@@ -1,4 +1,6 @@
-package com.traveljournal.domain.auth.dto;
+package com.traveljournal.domain.auth.dto.kakao;
+
+import com.traveljournal.domain.auth.dto.SocialMemberInfo;
 
 import lombok.Builder;
 
@@ -6,7 +8,7 @@ import lombok.Builder;
 public record KakaoMemberInfo(
 	Long id,
 	KakaoAccount kakao_account
-) {
+) implements SocialMemberInfo {
 	@Builder
 	public record KakaoAccount(
 		String email,
@@ -15,23 +17,36 @@ public record KakaoMemberInfo(
 
 	@Builder
 	public record Profile(
-		String nickname,
 		String profile_image_url
 	) {}
 
 	// of 메서드 추가
-	public static KakaoMemberInfo of(Long id, String email, String nickname, String profileImageUrl) {
+	public static KakaoMemberInfo of(Long id, String email, String profileImageUrl) {
 		return KakaoMemberInfo.builder()
 			.id(id)
 			.kakao_account(KakaoAccount.builder()
 				.email(email)
 				.profile(Profile.builder()
-					.nickname(nickname)
 					.profile_image_url(profileImageUrl)
 					.build()
 				)
 				.build()
 			)
 			.build();
+	}
+
+	@Override
+	public String getId() {
+		return id.toString();
+	}
+
+	@Override
+	public String getEmail() {
+		return kakao_account.email();
+	}
+
+	@Override
+	public String getProfileImageUrl() {
+		return kakao_account.profile().profile_image_url();
 	}
 }

--- a/src/main/java/com/traveljournal/domain/auth/dto/kakao/KakaoTokenResponse.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/kakao/KakaoTokenResponse.java
@@ -1,4 +1,4 @@
-package com.traveljournal.domain.auth.dto;
+package com.traveljournal.domain.auth.dto.kakao;
 
 public record KakaoTokenResponse(
 	String access_token,

--- a/src/main/java/com/traveljournal/domain/auth/service/AppleService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/AppleService.java
@@ -1,0 +1,258 @@
+package com.traveljournal.domain.auth.service;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.FileCopyUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.traveljournal.domain.auth.dto.LoginCombinedResponse;
+import com.traveljournal.domain.auth.dto.LoginResponse;
+import com.traveljournal.domain.auth.dto.apple.AppleIdTokenInfo;
+import com.traveljournal.domain.auth.dto.apple.AppleKeyInfo;
+import com.traveljournal.domain.auth.dto.apple.AppleMemberInfo;
+import com.traveljournal.domain.auth.dto.apple.ApplePublicKeyResponse;
+import com.traveljournal.domain.auth.dto.apple.AppleTokenResponse;
+import com.traveljournal.domain.auth.util.AppleClient;
+import com.traveljournal.domain.member.dto.TokenInfo;
+import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.entity.SocialProvider;
+import com.traveljournal.domain.member.service.MemberService;
+import com.traveljournal.domain.member.service.TokenService;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AppleService {
+	private final AppleClient appleClient;
+	private final TokenService tokenService;
+	private final MemberService memberService;
+	private final ObjectMapper objectMapper;
+
+	@Value("${oauth.apple.team-id}")
+	private String teamId;
+
+	@Value("${oauth.apple.services-id}")
+	private String servicesId;
+
+	@Value("${oauth.apple.key-id}")
+	private String keyId;
+
+	@Value("${oauth.apple.private-key-path}")
+	private String privateKeyPath;
+
+	@Value("${oauth.apple.redirect-uri}")
+	private String redirectUri;
+
+	@Value("${oauth.apple.ios-bundle-id}")
+	private String iosBundleId;
+
+	@Value("${oauth.apple.android-bundle-id}")
+	private String androidBundleId;
+
+	/**
+	 * 애플 로그인 처리
+	 * 1. 애플 인증 코드로 토큰 요청
+	 * 2. ID 토큰 검증 및 사용자 정보 추출
+	 * 3. 이메일로 회원 조회 또는 생성
+	 * 4. JWT 토큰 생성 및 저장
+	 * 5. 로그인 응답 생성
+	 */
+	public LoginCombinedResponse processAppleLoginWithCode(String code, String deviceId, SocialProvider socialProvider, String platform) {
+		// 애플 토큰 획득
+		AppleTokenResponse appleTokenResponse = getAppleToken(code);
+
+		return processAppleLoginWithIdToken(appleTokenResponse.idToken(), deviceId, socialProvider, platform);
+	}
+
+	public LoginCombinedResponse processAppleLoginWithIdToken(String idToken, String deviceId, SocialProvider socialProvider, String platform) {
+		// ID 토큰 검증 및 사용자 정보 추출
+		AppleIdTokenInfo appleIdTokenInfo = verifyAndParseIdToken(idToken, platform);
+
+		// 회원 찾기 또는 생성
+		Member member = getMemberFromIdToken(appleIdTokenInfo, socialProvider);
+
+		// JWT 토큰 생성 및 저장
+		TokenInfo tokenInfo = createAndSaveTokens(member, deviceId);
+
+		return createLoginResponse(member, tokenInfo);
+	}
+
+	// 애플 토큰 요청
+	public AppleTokenResponse getAppleToken(String code) {
+		String clientSecret = createClientSecret();
+		return appleClient.appleAuth(
+			servicesId,
+			code,
+			"authorization_code",
+			clientSecret,
+			redirectUri
+		);
+	}
+
+	// JWT 클라이언트 시크릿 생성
+	private String createClientSecret() {
+		Date expirationDate = Date.from(
+			LocalDateTime.now().plusMinutes(5)
+				.atZone(ZoneId.systemDefault())
+				.toInstant()
+		);
+
+		return Jwts.builder()
+			.setHeaderParam("kid", keyId)
+			.setHeaderParam("alg", "ES256")
+			.setIssuer(teamId)
+			.setIssuedAt(new Date())
+			.setExpiration(expirationDate)
+			.setAudience("https://appleid.apple.com")
+			.setSubject(servicesId)
+			.signWith(getPrivateKey(), SignatureAlgorithm.ES256)
+			.compact();
+	}
+
+	// 프라이빗 키 로드
+	private PrivateKey getPrivateKey() {
+		try {
+			Resource resource = new ClassPathResource(privateKeyPath.replace("classpath:", ""));
+			String privateKey = new String(FileCopyUtils.copyToByteArray(resource.getInputStream()));
+			privateKey = privateKey
+				.replace("-----BEGIN PRIVATE KEY-----", "")
+				.replace("-----END PRIVATE KEY-----", "")
+				.replaceAll("\\s", "");
+
+			byte[] keyBytes = Base64.getDecoder().decode(privateKey);
+			PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+			KeyFactory keyFactory = KeyFactory.getInstance("EC");
+			return keyFactory.generatePrivate(keySpec);
+		} catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
+			throw new RuntimeException("Failed to load private key", e);
+		}
+	}
+
+	// ID 토큰 검증 및 파싱
+	public AppleIdTokenInfo verifyAndParseIdToken(String idToken, String platform) {
+		try {
+			// 토큰 파싱
+			String[] tokenParts = idToken.split("\\.");
+			if (tokenParts.length != 3) {
+				throw new RuntimeException("Invalid ID token format");
+			}
+
+			// 헤더 파싱
+			String headerJson = new String(Base64.getUrlDecoder().decode(tokenParts[0]));
+			Map<String, String> header = objectMapper.readValue(headerJson, Map.class);
+			String kid = header.get("kid");
+			String alg = header.get("alg");
+
+			// 애플 공개키 가져오기
+			ApplePublicKeyResponse keyResponse = appleClient.getApplePublicKeys();
+
+			// kid와 alg에 맞는 공개키 찾기
+			AppleKeyInfo matchingKey = keyResponse.keys().stream()
+				.filter(key -> key.kid().equals(kid) && key.alg().equals(alg))
+				.findFirst()
+				.orElseThrow(() -> new RuntimeException("No matching key found"));
+
+			// 공개키 생성
+			PublicKey publicKey = generatePublicKey(matchingKey);
+
+			// 토큰 검증
+			Claims claims = Jwts.parserBuilder()
+				.setSigningKey(publicKey)
+				.build()
+				.parseClaimsJws(idToken)
+				.getBody();
+
+			// 클레임 검증
+			String issuer = claims.getIssuer();
+			if (!"https://appleid.apple.com".equals(issuer)) {
+				throw new RuntimeException("Invalid issuer: " + issuer);
+			}
+
+			String audience = claims.getAudience();
+			String expectedAudience;
+
+			if ("ios".equals(platform)) {
+				expectedAudience = iosBundleId;
+			} else if ("android".equals(platform)) {
+				expectedAudience = androidBundleId;
+			} else {
+				expectedAudience = servicesId; // 웹
+			}
+
+			if (!expectedAudience.equals(audience)) {
+				throw new RuntimeException("Invalid audience: " + audience);
+			}
+
+			Date expirationTime = claims.getExpiration();
+			if (expirationTime.before(new Date())) {
+				throw new RuntimeException("Token expired");
+			}
+
+			// 사용자 정보 추출
+			String subject = claims.getSubject(); // 애플 사용자 ID
+			String email = claims.get("email", String.class);
+			boolean emailVerified = claims.get("email_verified", Boolean.class);
+
+			// 사용자 정보가 담긴 객체 반환
+			return new AppleIdTokenInfo(subject, email, emailVerified);
+		} catch (Exception e) {
+			throw new RuntimeException("ID 토큰 검증 실패: " + e.getMessage(), e);
+		}
+	}
+
+	// 공개키 생성
+	private PublicKey generatePublicKey(AppleKeyInfo keyInfo) throws NoSuchAlgorithmException, InvalidKeySpecException {
+		BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(keyInfo.n()));
+		BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(keyInfo.e()));
+
+		RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(modulus, exponent);
+		KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+		return keyFactory.generatePublic(publicKeySpec);
+	}
+
+	private Member getMemberFromIdToken(AppleIdTokenInfo appleIdTokenInfo, SocialProvider socialProvider) {
+		return memberService.findOrCreateMember(
+			new AppleMemberInfo(
+				appleIdTokenInfo.sub(),
+				appleIdTokenInfo.email(),
+				null // 애플은 프로필 이미지를 제공하지 않음
+			),
+			socialProvider
+		);
+	}
+
+	private TokenInfo createAndSaveTokens(Member member, String deviceId) {
+		// JWT 토큰 생성
+		TokenInfo tokenInfo = tokenService.createTokens(member.getEmail(), deviceId);
+
+		// 토큰 저장
+		tokenService.saveOrUpdateToken(member, tokenInfo.deviceId(), tokenInfo.refreshToken());
+
+		return tokenInfo;
+	}
+
+	private LoginCombinedResponse createLoginResponse(Member member, TokenInfo tokenInfo) {
+		return LoginCombinedResponse.of(LoginResponse.from(member, tokenInfo), tokenInfo.accessToken());
+	}
+}

--- a/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
@@ -19,27 +19,28 @@ public class AuthService {
 	private final TokenService tokenService;
 	private final KakaoService kakaoService;
 	private final JwtTokenProvider jwtTokenProvider;
+	private final AppleService appleService;
 
 	@Transactional
-	public LoginCombinedResponse handleLoginWithCode(SocialProvider socialProvider, String code, String deviceId) {
-		switch (socialProvider) {
-			case KAKAO:
-				return kakaoService.processKakaoLoginWithCode(code, deviceId, socialProvider);
-			default:
-				throw new UnsupportedOperationException("지원되지 않는 소셜 로그인 제공자입니다.");
-		}
+	public LoginCombinedResponse handleLoginWithCode(SocialProvider socialProvider, String code, String deviceId,
+		String platform) {
+		return switch (socialProvider) {
+			case KAKAO -> kakaoService.processKakaoLoginWithCode(code, deviceId, socialProvider);
+			case APPLE -> appleService.processAppleLoginWithCode(code, deviceId, socialProvider, platform);
+			default -> throw new UnsupportedOperationException("지원되지 않는 소셜 로그인 제공자입니다.");
+		};
 	}
 
 	@Transactional
-	public LoginCombinedResponse handleLoginWithIdToken(SocialProvider socialProvider, String authorizationHeader, String deviceId) {
+	public LoginCombinedResponse handleLoginWithIdToken(SocialProvider socialProvider, String authorizationHeader,
+		String deviceId, String platform) {
 		String idToken = jwtTokenProvider.resolveToken(authorizationHeader);
 
-		switch (socialProvider) {
-			case KAKAO:
-				return kakaoService.processKakaoLoginWithIdToken(idToken, deviceId, socialProvider);
-			default:
-				throw new UnsupportedOperationException("지원되지 않는 소셜 로그인 제공자입니다.");
-		}
+		return switch (socialProvider) {
+			case KAKAO -> kakaoService.processKakaoLoginWithIdToken(idToken, deviceId, socialProvider);
+			case APPLE -> appleService.processAppleLoginWithIdToken(idToken, deviceId, socialProvider, platform);
+			default -> throw new UnsupportedOperationException("지원되지 않는 소셜 로그인 제공자입니다.");
+		};
 	}
 
 	/**
@@ -50,6 +51,5 @@ public class AuthService {
 	public void logout(Long memberId, String deviceId) {
 		tokenService.deleteToken(memberId, deviceId);
 	}
-
 
 }

--- a/src/main/java/com/traveljournal/domain/auth/service/KakaoService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/KakaoService.java
@@ -2,9 +2,9 @@ package com.traveljournal.domain.auth.service;
 
 import org.springframework.stereotype.Service;
 
-import com.traveljournal.domain.auth.dto.KakaoIdTokenInfo;
-import com.traveljournal.domain.auth.dto.KakaoMemberInfo;
-import com.traveljournal.domain.auth.dto.KakaoTokenResponse;
+import com.traveljournal.domain.auth.dto.kakao.KakaoIdTokenInfo;
+import com.traveljournal.domain.auth.dto.kakao.KakaoMemberInfo;
+import com.traveljournal.domain.auth.dto.kakao.KakaoTokenResponse;
 import com.traveljournal.domain.auth.dto.LoginCombinedResponse;
 import com.traveljournal.domain.auth.dto.LoginResponse;
 import com.traveljournal.domain.auth.util.KakaoClient;
@@ -58,7 +58,6 @@ public class KakaoService {
 			KakaoMemberInfo.of(
 				Long.parseLong(kakaoIdTokenInfo.sub()),
 				kakaoIdTokenInfo.email(),
-				kakaoIdTokenInfo.nickname(),
 				kakaoIdTokenInfo.profile_image_url()
 			), socialProvider
 		);

--- a/src/main/java/com/traveljournal/domain/auth/util/AppleClient.java
+++ b/src/main/java/com/traveljournal/domain/auth/util/AppleClient.java
@@ -1,0 +1,35 @@
+package com.traveljournal.domain.auth.util;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.traveljournal.domain.auth.dto.apple.ApplePublicKeyResponse;
+import com.traveljournal.domain.auth.dto.apple.AppleTokenResponse;
+
+@FeignClient(name = "apple-client", url = "https://appleid.apple.com")
+public interface AppleClient {
+	// 애플 공개 키 가져오기
+	@GetMapping("/auth/keys")
+	ApplePublicKeyResponse getApplePublicKeys();
+
+	// 토큰 요청
+	@PostMapping(value = "/auth/token", consumes = "application/x-www-form-urlencoded")
+	AppleTokenResponse appleAuth(
+		@RequestParam("client_id") String clientId,
+		@RequestParam("code") String code,
+		@RequestParam("grant_type") String grantType,
+		@RequestParam("client_secret") String clientSecret,
+		@RequestParam("redirect_uri") String redirectUri
+	);
+
+	// 토큰 취소 (로그아웃)
+	@PostMapping(value = "/auth/revoke", consumes = "application/x-www-form-urlencoded")
+	void revokeToken(
+		@RequestParam("client_id") String clientId,
+		@RequestParam("client_secret") String clientSecret,
+		@RequestParam("token") String token,
+		@RequestParam("token_type_hint") String tokenTypeHint
+	);
+}

--- a/src/main/java/com/traveljournal/domain/auth/util/EnumUtils.java
+++ b/src/main/java/com/traveljournal/domain/auth/util/EnumUtils.java
@@ -5,7 +5,7 @@ import com.traveljournal.domain.member.entity.SocialProvider;
 public class EnumUtils {
 	public static SocialProvider toSocialProvider(String socialProviderStr) {
 		try {
-			return SocialProvider.valueOf(socialProviderStr.toUpperCase());
+			return SocialProvider.valueOf(socialProviderStr.trim().toUpperCase());
 		} catch (IllegalArgumentException e) {
 			throw new IllegalArgumentException("Invalid SocialProvider: " + socialProviderStr, e);
 		}

--- a/src/main/java/com/traveljournal/domain/auth/util/KakaoClient.java
+++ b/src/main/java/com/traveljournal/domain/auth/util/KakaoClient.java
@@ -10,8 +10,8 @@ import org.springframework.web.client.RestTemplate;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import com.traveljournal.domain.auth.dto.KakaoIdTokenInfo;
-import com.traveljournal.domain.auth.dto.KakaoTokenResponse;
+import com.traveljournal.domain.auth.dto.kakao.KakaoIdTokenInfo;
+import com.traveljournal.domain.auth.dto.kakao.KakaoTokenResponse;
 import com.traveljournal.global.config.KakaoOAuthConfig;
 import com.traveljournal.global.exception.ExternalApiException;
 

--- a/src/main/java/com/traveljournal/domain/member/controller/MemberController.java
+++ b/src/main/java/com/traveljournal/domain/member/controller/MemberController.java
@@ -14,6 +14,7 @@ import com.traveljournal.global.data.ResponseHandler;
 import com.traveljournal.global.security.util.SecurityUtil;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -33,15 +34,20 @@ public class MemberController {
 	 */
 	@Operation(
 		summary = "Complete First Login",
-		description = "사용자 온보딩이 완료되었을 때 호출됩니다.",
-		security = @SecurityRequirement(name = "bearer-key")
+		description = """
+			사용자 온보딩이 완료되었을 때 호출됩니다.
+			<br> accountScope = (PUBLIC, FRIENDS, PRIVATE)""",
+		security = @SecurityRequirement(name = "bearer-key"),
+		responses = {
+			@ApiResponse(responseCode = "200", ref = "#/components/responses/Success")
+		}
 	)
 	@PostMapping("/complete-first-login")
 	public ResponseEntity<?> completeFirstLogin(@RequestBody FirstLoginRequest firstLoginRequest) {
 		Long memberId = SecurityUtil.getCurrentMemberId();
 
 		memberService.completeFirstLogin(memberId, firstLoginRequest);
-		return ResponseHandler.success("첫 로그인 완료 처리되었습니다.");
+		return ResponseHandler.success("요청이 성공적으로 처리되었습니다.");
 	}
 
 	@GetMapping("/check-nickname/{nickname}")
@@ -52,7 +58,11 @@ public class MemberController {
 			<br> 중복 닉네임 : 상태코드 409 / duplicate
 			<br> 비속어 닉네임 : 상태코드 409 / containsBadWord
 			<br> 사용가능한 닉네임 : 상태코드 200 / valid""",
-		security = @SecurityRequirement(name = "bearer-key")
+		security = @SecurityRequirement(name = "bearer-key"),
+		responses = {
+			@ApiResponse(responseCode = "200", ref = "#/components/responses/ValidName"),
+			@ApiResponse(responseCode = "409", ref = "#/components/responses/DuplicateName")
+		}
 	)
 	public ResponseEntity<?> checkNickname(@PathVariable("nickname") String nickname) {
 		// if (memberService.isProfane(nickname)) {

--- a/src/main/java/com/traveljournal/domain/member/controller/MemberController.java
+++ b/src/main/java/com/traveljournal/domain/member/controller/MemberController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.traveljournal.domain.auth.dto.FirstLoginRequest;
 import com.traveljournal.domain.member.service.MemberService;
-import com.traveljournal.global.data.ApiResponse;
+import com.traveljournal.global.data.ResponseHandler;
 import com.traveljournal.global.security.util.SecurityUtil;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,7 +41,7 @@ public class MemberController {
 		Long memberId = SecurityUtil.getCurrentMemberId();
 
 		memberService.completeFirstLogin(memberId, firstLoginRequest);
-		return ApiResponse.success("첫 로그인 완료 처리되었습니다.");
+		return ResponseHandler.success("첫 로그인 완료 처리되었습니다.");
 	}
 
 	@GetMapping("/check-nickname/{nickname}")
@@ -60,9 +60,9 @@ public class MemberController {
 		// } 비속어 추후 구현 -> mysql 로컬 내부에 있음
 		if (memberService.isDuplicate(nickname)) {
 			log.info("Check nickname {}", nickname);
-			return ApiResponse.onFailure("duplicate");
+			return ResponseHandler.onFailure("duplicate");
 		}
 		else
-			return ApiResponse.success("valid");
+			return ResponseHandler.success("valid");
 	}
 }

--- a/src/main/java/com/traveljournal/domain/member/controller/TokenController.java
+++ b/src/main/java/com/traveljournal/domain/member/controller/TokenController.java
@@ -10,7 +10,7 @@ import com.traveljournal.domain.member.dto.MemberTokenResponse;
 import com.traveljournal.domain.member.dto.ReissueRequest;
 import com.traveljournal.domain.member.dto.ReissueResponse;
 import com.traveljournal.domain.member.service.TokenService;
-import com.traveljournal.global.data.ApiResponse;
+import com.traveljournal.global.data.ResponseHandler;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -35,6 +35,6 @@ public class TokenController {
 	@PostMapping("/reissue")
 	public ResponseEntity<ReissueResponse> refreshToken(@RequestBody ReissueRequest Reissuerequest) {
 		MemberTokenResponse memberTokenResponse = tokenService.refreshToken(Reissuerequest);
-		return ApiResponse.accessTokenResponse(ReissueResponse.of(memberTokenResponse), memberTokenResponse.tokenInfo().accessToken());
+		return ResponseHandler.accessTokenResponse(ReissueResponse.of(memberTokenResponse), memberTokenResponse.tokenInfo().accessToken());
 	}
 }

--- a/src/main/java/com/traveljournal/domain/member/dto/ReissueResponse.java
+++ b/src/main/java/com/traveljournal/domain/member/dto/ReissueResponse.java
@@ -5,21 +5,12 @@ import lombok.Builder;
 
 @Builder
 public record ReissueResponse(
-	@Schema(example = "1")
-	Long memberId,
-	@Schema(example = "true")
-	String email,
 	@Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJsdW5hcmlzMDIwNkBuYXZlci5jb20iLCJpYXE3NDMsImV4cCI6MTc0MjIwMDAzM30.nf5sYgC3nQ-ysA3yRdHBpTXjzSdyIsIGQWxdYeT1tt8")
-	String refreshToken,
-	@Schema(example = "8bd0476d-e790-4133-bbfe-3a90f6757537")
-	String deviceId
+	String refreshToken
 ) {
 	public static ReissueResponse of(MemberTokenResponse memberTokenResponse) {
 		return ReissueResponse.builder()
-			.memberId(memberTokenResponse.memberId())
-			.email(memberTokenResponse.email())
 			.refreshToken(memberTokenResponse.tokenInfo().refreshToken())
-			.deviceId(memberTokenResponse.tokenInfo().deviceId())
 			.build();
 	}
 }

--- a/src/main/java/com/traveljournal/domain/member/service/MemberService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/MemberService.java
@@ -1,12 +1,13 @@
 package com.traveljournal.domain.member.service;
 
 import java.util.Optional;
+import java.util.Random;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.traveljournal.domain.auth.dto.FirstLoginRequest;
-import com.traveljournal.domain.auth.dto.KakaoMemberInfo;
+import com.traveljournal.domain.auth.dto.SocialMemberInfo;
 import com.traveljournal.domain.member.entity.AccountScope;
 import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.member.entity.SocialProvider;
@@ -44,8 +45,8 @@ public class MemberService {
 	 * 카카오 회원정보를 바탕으로 회원 조회 또는 생성
 	 */
 	@Transactional
-	public Member findOrCreateMember(KakaoMemberInfo kakaoMemberInfo, SocialProvider socialProvider) {
-		String email = kakaoMemberInfo.kakao_account().email();
+	public Member findOrCreateMember(SocialMemberInfo socialMemberInfo, SocialProvider socialProvider) {
+		String email = socialMemberInfo.getEmail();
 
 		Optional<Member> existingMember = findByEmail(email);
 
@@ -53,16 +54,19 @@ public class MemberService {
 			return existingMember.get();
 		}
 
-		Member newMember = createNewMember(kakaoMemberInfo, socialProvider);
+		Member newMember = createNewMember(socialMemberInfo, socialProvider);
 
 		return memberRepository.save(newMember);
 	}
 
-	public Member createNewMember(KakaoMemberInfo kakaoMemberInfo, SocialProvider socialProvider) {
+	public Member createNewMember(SocialMemberInfo socialMemberInfo, SocialProvider socialProvider) {
+
+		String randomNickname = generateRandomNickname();
+		
 		return Member.builder()
-			.email(kakaoMemberInfo.kakao_account().email())
-			.nickname(kakaoMemberInfo.kakao_account().profile().nickname())
-			.profileImageUrl(kakaoMemberInfo.kakao_account().profile().profile_image_url())
+			.email(socialMemberInfo.getEmail())
+			.nickname(randomNickname)
+			.profileImageUrl(socialMemberInfo.getProfileImageUrl())
 			.accountScope(AccountScope.PUBLIC)
 			.socialProvider(socialProvider)
 			.build();
@@ -92,5 +96,34 @@ public class MemberService {
 	@Transactional(readOnly = true)
 	public boolean isDuplicate(String nickname) {
 		return memberRepository.findByNickname(nickname) != null;
+	}
+
+	private String generateRandomNickname() {
+		// 알파벳 문자열 정의
+		String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+		String lowerAlphabet = alphabet.toLowerCase();
+
+		// 랜덤 객체 생성
+		Random random = new Random();
+
+		// StringBuilder 생성
+		StringBuilder sb = new StringBuilder();
+
+		// 랜덤 닉네임 길이 (예: 8자)
+		int length = 8;
+
+		// 첫 글자는 대문자로
+		sb.append(alphabet.charAt(random.nextInt(alphabet.length())));
+
+		// 나머지 글자 생성
+		for(int i = 1; i < length; i++) {
+			sb.append(lowerAlphabet.charAt(random.nextInt(lowerAlphabet.length())));
+		}
+
+		// 숫자 추가 (예: 10-99)
+		int randomNumber = random.nextInt(90) + 10;
+		sb.append(randomNumber);
+
+		return "User" + sb.toString();
 	}
 }

--- a/src/main/java/com/traveljournal/global/config/FeignConfig.java
+++ b/src/main/java/com/traveljournal/global/config/FeignConfig.java
@@ -1,0 +1,14 @@
+package com.traveljournal.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import feign.Logger;
+
+@Configuration
+public class FeignConfig {
+	@Bean
+	Logger.Level feginLoggerLevel() {
+		return Logger.Level.FULL;
+	}
+}

--- a/src/main/java/com/traveljournal/global/config/SecurityConfig.java
+++ b/src/main/java/com/traveljournal/global/config/SecurityConfig.java
@@ -65,7 +65,10 @@ public class SecurityConfig {
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
 
-		configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+		configuration.setAllowedOrigins(List.of(
+			"http://localhost:3000",
+			"https://travel-journal.shop",
+			"https://appleid.apple.com"));
 		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
 		configuration.setAllowedHeaders(List.of("*"));
 		configuration.setExposedHeaders(List.of("Authorization"));

--- a/src/main/java/com/traveljournal/global/config/SwaggerConfig.java
+++ b/src/main/java/com/traveljournal/global/config/SwaggerConfig.java
@@ -1,13 +1,18 @@
 package com.traveljournal.global.config;
 
+import java.util.HashMap;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
@@ -20,13 +25,69 @@ public class SwaggerConfig {
 	public OpenAPI openAPI() {
 		Info info = new Info()
 			.version("v1")
-			.title("Open API Definition");
+			.title("Travel Journal API")
+			.description("여행 일지 애플리케이션의 API 문서입니다.");
 
 		Server server = new Server();
 		server.setUrl(requestUrl);
+		server.setDescription("API 서버");
+
+		// 공통 응답 정의
+		Components components = new Components()
+			.addResponses("Success", new ApiResponse()
+				.description("성공 응답")
+				.content(new Content().addMediaType("application/json",
+					new MediaType().example(new HashMap<String, Object>() {{
+						put("success", true);
+						put("message", "요청이 성공적으로 처리되었습니다.");
+						put("data", null);
+					}})
+				))
+			)
+			.addResponses("Logout", new ApiResponse()
+				.description("성공 응답")
+				.content(new Content().addMediaType("application/json",
+					new MediaType().example(new HashMap<String, Object>() {{
+						put("success", true);
+						put("message", "로그아웃 성공");
+						put("data", null);
+					}})
+				))
+			)
+			.addResponses("ValidName", new ApiResponse()
+				.description("성공 응답")
+				.content(new Content().addMediaType("application/json",
+					new MediaType().example(new HashMap<String, Object>() {{
+						put("success", true);
+						put("message", "valid");
+						put("data", null);
+					}})
+				))
+			)
+			.addResponses("DuplicateName", new ApiResponse()
+				.description("실패 응답 - 중복 닉네임")
+				.content(new Content().addMediaType("application/json",
+					new MediaType().example(new HashMap<String, Object>() {{
+						put("success", false);
+						put("message", "duplicate");
+						put("data", null);
+					}})
+				))
+			)
+			.addResponses("Unauthorized", new ApiResponse()
+				.description("인증 실패")
+				.content(new Content().addMediaType("application/json",
+					new MediaType().example(new HashMap<String, Object>() {{
+						put("success", false);
+						put("message", "인증에 실패했습니다.");
+						put("data", null);
+					}})
+				))
+			);
 
 		return new OpenAPI()
 			.info(info)
-			.servers(List.of(server));
+			.servers(List.of(server))
+			.components(components);
 	}
 }

--- a/src/main/java/com/traveljournal/global/data/ResponseDto.java
+++ b/src/main/java/com/traveljournal/global/data/ResponseDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ApiResult<T> {
+public class ResponseDto<T> {
 	private boolean success;
 	private String message;
 	private T data;

--- a/src/main/java/com/traveljournal/global/data/ResponseHandler.java
+++ b/src/main/java/com/traveljournal/global/data/ResponseHandler.java
@@ -4,13 +4,13 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-public class ApiResponse {
+public class ResponseHandler {
 
 	/**
 	 * 일반 성공 응답
 	 */
-	public static <T> ResponseEntity<ApiResult<T>> ok(T data) {
-		ApiResult<T> result = ApiResult.<T>builder()
+	public static <T> ResponseEntity<ResponseDto<T>> ok(T data) {
+		ResponseDto<T> result = ResponseDto.<T>builder()
 			.success(true)
 			.message("요청이 성공적으로 처리되었습니다.")
 			.data(data)
@@ -21,8 +21,8 @@ public class ApiResponse {
 	/**
 	 * 생성 성공 응답
 	 */
-	public static <T> ResponseEntity<ApiResult<T>> created(T data) {
-		ApiResult<T> result = ApiResult.<T>builder()
+	public static <T> ResponseEntity<ResponseDto<T>> created(T data) {
+		ResponseDto<T> result = ResponseDto.<T>builder()
 			.success(true)
 			.message("데이터가 성공적으로 생성되었습니다.")
 			.data(data)
@@ -33,8 +33,8 @@ public class ApiResponse {
 	/**
 	 * 성공 응답 (수정, 삭제)
 	 */
-	public static ResponseEntity<ApiResult<Void>> success(String message) {
-		ApiResult<Void> result = ApiResult.<Void>builder()
+	public static ResponseEntity<ResponseDto<Void>> success(String message) {
+		ResponseDto<Void> result = ResponseDto.<Void>builder()
 			.success(true)
 			.message(message)
 			.build();
@@ -56,8 +56,8 @@ public class ApiResponse {
 	/**
 	 * 실패 응답
 	 */
-	public static ResponseEntity<ApiResult<Void>> onFailure(String message) {
-		ApiResult<Void> result = ApiResult.<Void>builder()
+	public static ResponseEntity<ResponseDto<Void>> onFailure(String message) {
+		ResponseDto<Void> result = ResponseDto.<Void>builder()
 			.success(false)
 			.message(message)
 			.build();


### PR DESCRIPTION
## 🔥 해결된 이슈
- Closes #14 
- JIRA #TJFE-61

## 📌 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련된 테스트를 추가하거나 기존 테스트를 실행하여 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드를 따랐는지 확인했습니다.
- [x] 배포가 필요한 경우 관련 작업을 완료했습니다. (예: CI/CD 설정, 환경 변수 추가 등)

## ✨ 작업 내용
1. Swagger Responses 추가 생성
- Swagger에서 자동으로 인식을 하지 못하여 Config로 공동 응답값을 생성하여 작업
- 현재는 성공 응답만 작성하였으며 추후 실패하였을때의 응답값도 설정 예정
- 예외사항으로는 중복 닉네임은 실패 응답으로 구현되어 있습니다.

2. 애플 로그인
- 애플 로그인 시 플랫폼을 지정해주어야합니다.
-> X-Platform Header에 web, ios, android에 맞게 작성해주셔야합니다.
GET /v1/auth/login/{socialProvider}/callback
POST /v1/auth/login/{socialProvider}/id-token

로그인은 두 방식을 채용합니다. (인가코드, id_token)
 
*ps. 기존 카카오 로그인의 경우 플랫폼 입력을 하지 않아도 가능합니다. 애플 로그인만 플랫폼 지정 필수

3. 유니크한 닉네임을 위해 랜덤 닉네임 생성합니다.
-> 예시 UserCanleuza38
- 필요할 경우 제공 가능합니다.

## 🚀 추가 설명
> 중복 로직, 토큰 만료 등 각종 응답값 프론트에서 원인을 알 수 있도록 수정할 예정입니다.
SDK로 로그인하는것은 아직 테스트 못해보았습니다. 앱 개발자분들께서 테스트해주셔야 가능

** ApiResponse가 변경되었습니다. Swagger 어노테이션과 중복으로 인하여 네이밍 변경... **

## 📸 테스트 결과 (스크린샷 혹은 로그)
> [스크린샷 혹은 테스트 정상 확인 로그를 첨부해주세요.]
![image](https://github.com/user-attachments/assets/1e78bfb9-6eff-4171-adb9-1563479990ff)
![image](https://github.com/user-attachments/assets/eaf66ea0-4200-4cc9-a8bf-2f9a92864849)
