### PR TITLE
[feature] google 소셜 로그인 연동 해제 및 회원 탈퇴 기능

### DIFF
--- a/src/main/java/com/traveljournal/domain/auth/dto/google/GoogleTokenResponse.java
+++ b/src/main/java/com/traveljournal/domain/auth/dto/google/GoogleTokenResponse.java
@@ -1,9 +1,11 @@
 package com.traveljournal.domain.auth.dto.google;
 
 // 구글 로그인 후 반환되는 토큰 정보를 받아올 DTO
-public record GoogleTokenResponse (
-    String access_token,
-    String token_type,
-    String id_token,
-    String scope
-){ }
+public record GoogleTokenResponse(
+	String access_token,
+	String refresh_token,
+	String token_type,
+	String id_token,
+	String scope
+) {
+}

--- a/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
@@ -48,7 +48,7 @@ public class AuthService {
 		return switch (socialProvider) {
 			case KAKAO -> kakaoService.processKakaoLoginWithIdToken(idToken, deviceId, socialProvider);
 			case APPLE -> appleService.processAppleLoginWithIdToken(idToken, deviceId, socialProvider, platform, refreshToken);
-			case GOOGLE -> googleService.processGoogleLoginWithIdToken(idToken, deviceId, socialProvider);
+			case GOOGLE -> googleService.processGoogleLoginWithIdToken(idToken, deviceId, socialProvider, refreshToken);
 			default -> throw new UnsupportedOperationException("지원되지 않는 소셜 로그인 제공자입니다.");
 		};
 	}

--- a/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
@@ -63,6 +63,9 @@ public class AuthService {
 			case APPLE:
 				appleService.unlinkAppleAccount(memberId);
 				break;
+			case GOOGLE:
+				googleService.unlinkGoogleAccount(memberId);
+				break;
 			default:
 				throw new UnsupportedOperationException("지원되지 않는 소셜 로그인 제공자입니다.");
 		}

--- a/src/main/java/com/traveljournal/domain/auth/service/GoogleService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/GoogleService.java
@@ -1,5 +1,7 @@
 package com.traveljournal.domain.auth.service;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Service;
 
 import com.traveljournal.domain.auth.dto.LoginCombinedResponse;
@@ -12,6 +14,7 @@ import com.traveljournal.domain.member.dto.TokenInfo;
 import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.member.entity.SocialProvider;
 import com.traveljournal.domain.member.service.MemberService;
+import com.traveljournal.domain.member.service.SocialTokenService;
 import com.traveljournal.domain.member.service.TokenService;
 
 import lombok.RequiredArgsConstructor;
@@ -23,17 +26,18 @@ public class GoogleService {
 	private final TokenService tokenService;
 	private final MemberService memberService;
 	private final GoogleClient googleClient;
+	private final SocialTokenService socialTokenService;
 
 	public LoginCombinedResponse processGoogleLoginWithCode(String code, String deviceId,
 		SocialProvider socialProvider) {
 		// 구글 토큰 획득
 		GoogleTokenResponse googleTokenResponse = googleClient.getGoogleToken(code);
 
-		return processGoogleLoginWithIdToken(googleTokenResponse.id_token(), deviceId, socialProvider);
+		return processGoogleLoginWithIdToken(googleTokenResponse.id_token(), deviceId, socialProvider, googleTokenResponse.refresh_token());
 	}
 
 	public LoginCombinedResponse processGoogleLoginWithIdToken(String idToken, String deviceId,
-		SocialProvider socialProvider) {
+		SocialProvider socialProvider, String refreshToken) {
 		// ID Token 으로 구글 사용자 정보 가져오기
 		GoogleIdTokenInfo googleIdTokenInfo = googleClient.getGoogleMemberInfoFromIdToken(idToken);
 
@@ -42,6 +46,15 @@ public class GoogleService {
 
 		// JWT 토큰 생성 및 저장
 		TokenInfo tokenInfo = createAndSaveTokens(member, deviceId);
+
+		if (refreshToken != null && !refreshToken.isEmpty()) {
+			LocalDateTime expiryDate = LocalDateTime.now().plusMonths(6);
+			socialTokenService.saveOrUpdateSocialToken(
+				member.getId(),
+				refreshToken,
+				socialProvider,
+				expiryDate);
+		}
 
 		// 로그인 응답 생성
 		return createLoginResponse(member, tokenInfo);

--- a/src/main/java/com/traveljournal/domain/auth/service/GoogleService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/GoogleService.java
@@ -2,6 +2,8 @@ package com.traveljournal.domain.auth.service;
 
 import java.time.LocalDateTime;
 
+import lombok.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import com.traveljournal.domain.auth.dto.LoginCombinedResponse;
@@ -18,6 +20,10 @@ import com.traveljournal.domain.member.service.SocialTokenService;
 import com.traveljournal.domain.member.service.TokenService;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +33,8 @@ public class GoogleService {
 	private final MemberService memberService;
 	private final GoogleClient googleClient;
 	private final SocialTokenService socialTokenService;
+	private final RestTemplate restTemplate;
+
 
 	public LoginCombinedResponse processGoogleLoginWithCode(String code, String deviceId,
 		SocialProvider socialProvider) {
@@ -83,5 +91,42 @@ public class GoogleService {
 
 	private LoginCombinedResponse createLoginResponse(Member member, TokenInfo tokenInfo) {
 		return LoginCombinedResponse.of(LoginResponse.from(member, tokenInfo), tokenInfo.accessToken());
+	}
+
+
+	public void unlinkGoogleAccount(Long memberId) {
+		// 회원 정보 조회
+		Member member = memberService.findById(memberId);
+		// 회원의 구글 식별자(sub) 가져오기
+		String googleUserId = member.getProviderId();
+
+		if (googleUserId == null || googleUserId.isEmpty()) {
+			throw new RuntimeException("구글 계정 연결 정보가 없습니다.");
+		}
+
+		try {
+			// 리프레시 토큰 조회 및 처리
+			Optional<String> refreshTokenOpt = socialTokenService.getSocialRefreshToken(memberId, SocialProvider.GOOGLE);
+
+			if (refreshTokenOpt.isPresent()) {
+				String refreshToken = refreshTokenOpt.get();
+
+				// 구글 연동 해제 요청 (토큰 폐기 API 호출)
+				String revokeUrl = "https://oauth2.googleapis.com/revoke?token=" + refreshToken;
+				ResponseEntity<String> response = restTemplate.postForEntity(revokeUrl, null, String.class);
+
+				if (response.getStatusCode().is2xxSuccessful()) {
+					// 회원 계정에서 구글 연결 정보 삭제
+					memberService.deleteMember(memberId);
+				} else {
+					throw new RuntimeException("구글 계정 연결 해제 실패");
+				}
+			} else {
+				throw new RuntimeException("구글 리프레시 토큰을 찾을 수 없습니다.");
+			}
+
+		} catch (Exception e) {
+			throw new RuntimeException("구글 계정 연결 해제 실패: " + e.getMessage(), e);
+		}
 	}
 }

--- a/src/main/java/com/traveljournal/domain/auth/service/GoogleService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/GoogleService.java
@@ -111,19 +111,12 @@ public class GoogleService {
 			if (refreshTokenOpt.isPresent()) {
 				String refreshToken = refreshTokenOpt.get();
 
-				// 구글 연동 해제 요청 (토큰 폐기 API 호출)
-				String revokeUrl = "https://oauth2.googleapis.com/revoke?token=" + refreshToken;
-				ResponseEntity<String> response = restTemplate.postForEntity(revokeUrl, null, String.class);
+				googleClient.revokeToken(refreshToken);
 
-				if (response.getStatusCode().is2xxSuccessful()) {
-					// 회원 계정에서 구글 연결 정보 삭제
-					memberService.deleteMember(memberId);
-				} else {
+				memberService.deleteMember(memberId);
+			} else {
 					throw new RuntimeException("구글 계정 연결 해제 실패");
 				}
-			} else {
-				throw new RuntimeException("구글 리프레시 토큰을 찾을 수 없습니다.");
-			}
 
 		} catch (Exception e) {
 			throw new RuntimeException("구글 계정 연결 해제 실패: " + e.getMessage(), e);

--- a/src/main/java/com/traveljournal/domain/auth/util/GoogleClient.java
+++ b/src/main/java/com/traveljournal/domain/auth/util/GoogleClient.java
@@ -3,9 +3,7 @@ package com.traveljournal.domain.auth.util;
 import java.net.URL;
 import java.text.ParseException;
 
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
+import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -159,6 +157,14 @@ public class GoogleClient {
         } catch (Exception e) {
             log.error("ID Token 파싱 실패 : {}", e.getMessage());
             throw new ExternalApiException("ID Token 파싱에 실패했습니다." + e.getMessage());
+        }
+    }
+
+    public void revokeToken(String refreshToken) {
+        String revokeUrl = "https://oauth2.googleapis.com/revoke?token=" + refreshToken;
+        ResponseEntity<String> response = restTemplate.postForEntity(revokeUrl, null, String.class);
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new RuntimeException("구글 계정 연결 해제 실패");
         }
     }
 }

--- a/src/main/java/com/traveljournal/domain/auth/util/GoogleClient.java
+++ b/src/main/java/com/traveljournal/domain/auth/util/GoogleClient.java
@@ -162,9 +162,11 @@ public class GoogleClient {
 
     public void revokeToken(String refreshToken) {
         String revokeUrl = "https://oauth2.googleapis.com/revoke?token=" + refreshToken;
-        ResponseEntity<String> response = restTemplate.postForEntity(revokeUrl, null, String.class);
-        if (!response.getStatusCode().is2xxSuccessful()) {
-            throw new RuntimeException("구글 계정 연결 해제 실패");
+
+        try {
+            restTemplate.postForObject(revokeUrl, null, String.class);
+        } catch (Exception e) {
+            throw new RuntimeException("구글 계정 연결 해제 실패",e);
         }
     }
 }

--- a/src/main/java/com/traveljournal/domain/auth/util/GoogleClient.java
+++ b/src/main/java/com/traveljournal/domain/auth/util/GoogleClient.java
@@ -36,17 +36,6 @@ public class GoogleClient {
      * 구글 인증 코드로 토큰 정보 요청
      */
     public GoogleTokenResponse getGoogleToken(String code) {
-        /*
-        String url = "https://accounts.google.com/o/oauth2/v2/auth?";
-        String body = "code=" + code +
-                "&client_id=" + "${google.clientId}" +
-                "&client_secret=" + "${google.clientSecret}" +
-                "&redirect_uri=" + "${google.RedirectUri}" +
-                "&grant_type=authorization_code";
-
-        return restTemplate.postForObject(url, body, GoogleTokenResponse.class);
-
-         */
         try {
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);

--- a/src/main/java/com/traveljournal/domain/auth/util/GoogleClient.java
+++ b/src/main/java/com/traveljournal/domain/auth/util/GoogleClient.java
@@ -1,5 +1,16 @@
 package com.traveljournal.domain.auth.util;
 
+import java.net.URL;
+import java.text.ParseException;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
@@ -10,18 +21,9 @@ import com.traveljournal.domain.auth.dto.google.GoogleMemberInfo;
 import com.traveljournal.domain.auth.dto.google.GoogleTokenResponse;
 import com.traveljournal.global.config.GoogleOAuthConfig;
 import com.traveljournal.global.exception.ExternalApiException;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
-
-import java.net.URL;
-import java.text.ParseException;
 
 @Component
 @RequiredArgsConstructor
@@ -55,6 +57,8 @@ public class GoogleClient {
             params.add("client_secret", googleOAuthConfig.getClientSecret());
             params.add("redirect_uri", googleOAuthConfig.getRedirectUri());
             params.add("grant_type", "authorization_code");
+            params.add("access_type", "offline");  // 리프레시 토큰을 받기 위한 설정
+            params.add("prompt", "consent");
             log.info("🚀 Google OAuth 요청 - clientId: {}, clientSecret: {}, redirectUri: {}",
                     googleOAuthConfig.getClientId(),
                     googleOAuthConfig.getClientSecret(),

--- a/src/main/java/com/traveljournal/domain/member/service/SocialTokenService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/SocialTokenService.java
@@ -41,6 +41,7 @@ public class SocialTokenService {
 				.refreshToken(refreshToken)
 				.provider(provider)
 				.expiryDate(expiryDate)
+				.providerId(member.getProviderId())
 				.build();
 			socialTokenRepository.save(token);
 		}


### PR DESCRIPTION
## 🔥 해결된 이슈
- Closes #20 
- Jira TJFE-114
## 📌 체크리스트
- [X] 코드가 정상적으로 동작하는지 확인했습니다.
- [X] 관련된 테스트를 추가하거나 기존 테스트를 실행하여 통과했는지 확인했습니다.
- [X] 코드 스타일 가이드를 따랐는지 확인했습니다.
- [X] 배포가 필요한 경우 관련 작업을 완료했습니다. (예: CI/CD 설정, 환경 변수 추가 등)

## ✨ 작업 내용
구글 계정 연동 끊기 기능 추가
- refresh_token을 이용하여 구글계정 연동해제

## 🚀 추가 설명
구글 OAuth 로그인 시, Refresh Token을 받기 위해 아래 파라미터를 추가해야 합니다.
- access_type=offline → Refresh Token을 받기 위해 필수
- prompt=consent → 기존 Refresh Token이 만료되었을 때 새로운 Token을 받기 위함

 예시 로그인 요청 (필수 파라미터 포함)
https://accounts.google.com/o/oauth2/auth
?client_id={client_id}
&redirect_uri=https://travel-journal.shop/auth/google/callback
&response_type=code
&scope=openid email profile
&access_type=offline
&prompt=consent

## 📸 테스트 결과 (스크린샷 혹은 로그)
- 회원 가입 시 
![가입](https://github.com/user-attachments/assets/021f5d8b-ddb2-474c-b374-2bf1865fb215)

- 연동 해제
![연동해제](https://github.com/user-attachments/assets/182b6cbc-8a23-4f74-860c-0ed329d8f032)

- 연동 해제 후 
![해제](https://github.com/user-attachments/assets/a113d791-5f71-49fa-ae38-0c0d06c07488)
