### PR TITLE
[Feature] 사용자 검색 기능 구현

### DIFF
--- a/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
+++ b/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
@@ -1,0 +1,38 @@
+package com.traveljournal.domain.search.controller;
+
+import com.traveljournal.domain.search.dto.MemberSearchResponse;
+import com.traveljournal.domain.search.service.MemberSearchService;
+import com.traveljournal.global.data.ApiResponseHandler;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/search")
+@Tag(name = "Search API", description = "사용자 검색")
+public class SearchController {
+
+    private final MemberSearchService memberSearchService;
+
+    @GetMapping
+    public ResponseEntity<?> searchMembers(@RequestParam String keyword,
+                                           @PageableDefault(size = 10, sort = "nickname") Pageable pageable)
+    {
+        Page<MemberSearchResponse> result = memberSearchService.searchMembers(keyword, pageable);
+        if(result.isEmpty()) {
+            return ApiResponseHandler.onFailure("검색 결과가 없습니다.");
+        }
+
+        return ApiResponseHandler.getObjectSuccess(result);
+    }
+}

--- a/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
+++ b/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
@@ -6,32 +6,45 @@ import com.traveljournal.global.data.ApiResponseHandler;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@Valid
 @RequestMapping("/v1/search")
 @Tag(name = "Search API", description = "사용자 검색")
 public class SearchController {
 
     private final MemberSearchService memberSearchService;
 
-    @GetMapping
+    @GetMapping("/members")
     @Operation(
             summary = "사용자 검색",
             description = "사용자가 입력한 키워드로 다른 사용자를 검색합니다.",
             security = @SecurityRequirement(name = "bearer-key"))
     public ResponseEntity<?> searchMembers(
-            @RequestParam String keyword, @PageableDefault(size = 10, sort = "nickname") Pageable pageable)
+            @RequestParam @NotBlank(message = "검색어는 비어 있을 수 없습니다.") String keyword,
+            @PageableDefault(sort = "nickname") Pageable pageable)
     {
+/*
+        // 키워드가 비어 있을 경우, 409 상태 코드로 실패 메시지 반환
+        if (keyword == null || keyword.isEmpty()) {
+            return ApiResponseHandler.onFailure("검색어는 비어 있을 수 없습니다.");
+        }
+
+ */
+        // 검색 결과가 없을 경우, "검색 결과가 없습니다." 메시지와 함께 200 반환
         Page<MemberSearchResponse> result = memberSearchService.searchMembers(keyword, pageable);
         if(result.isEmpty()) {
-            return ApiResponseHandler.onFailure("검색 결과가 없습니다.");
+            return ApiResponseHandler.onSuccess("검색 결과가 없습니다.");
         }
 
         return ApiResponseHandler.getObjectSuccess(result);

--- a/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
+++ b/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
@@ -3,18 +3,15 @@ package com.traveljournal.domain.search.controller;
 import com.traveljournal.domain.search.dto.MemberSearchResponse;
 import com.traveljournal.domain.search.service.MemberSearchService;
 import com.traveljournal.global.data.ApiResponseHandler;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,8 +22,12 @@ public class SearchController {
     private final MemberSearchService memberSearchService;
 
     @GetMapping
-    public ResponseEntity<?> searchMembers(@RequestParam String keyword,
-                                           @PageableDefault(size = 10, sort = "nickname") Pageable pageable)
+    @Operation(
+            summary = "사용자 검색",
+            description = "사용자가 입력한 키워드로 다른 사용자를 검색합니다.",
+            security = @SecurityRequirement(name = "bearer-key"))
+    public ResponseEntity<?> searchMembers(
+            @RequestParam String keyword, @PageableDefault(size = 10, sort = "nickname") Pageable pageable)
     {
         Page<MemberSearchResponse> result = memberSearchService.searchMembers(keyword, pageable);
         if(result.isEmpty()) {

--- a/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
+++ b/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
@@ -41,11 +41,7 @@ public class SearchController {
         }
 
  */
-        // 검색 결과가 없을 경우, "검색 결과가 없습니다." 메시지와 함께 200 반환
         Page<MemberSearchResponse> result = memberSearchService.searchMembers(keyword, pageable);
-        if(result.isEmpty()) {
-            return ApiResponseHandler.onSuccess("검색 결과가 없습니다.");
-        }
 
         return ApiResponseHandler.getObjectSuccess(result);
     }

--- a/src/main/java/com/traveljournal/domain/search/dto/MemberSearchResponse.java
+++ b/src/main/java/com/traveljournal/domain/search/dto/MemberSearchResponse.java
@@ -1,0 +1,24 @@
+package com.traveljournal.domain.search.dto;
+
+import com.traveljournal.domain.member.dto.MemberProfileResponse;
+import com.traveljournal.domain.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record MemberSearchResponse (
+        Long id,
+        String nickname,
+        String profileImageUrl,
+        Long travelDiaryCount,
+        Long placesCount
+) {
+    public static MemberSearchResponse of(Long id, MemberProfileResponse profileResponse) {
+        return MemberSearchResponse.builder()
+                .id(id)
+                .nickname(profileResponse.nickname())
+                .profileImageUrl(profileResponse.profileImageUrl())
+                .travelDiaryCount(profileResponse.travelDiaryCount())
+                .placesCount(profileResponse.placesCount())
+                .build();
+    }
+}

--- a/src/main/java/com/traveljournal/domain/search/dto/MemberSearchResponse.java
+++ b/src/main/java/com/traveljournal/domain/search/dto/MemberSearchResponse.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 
 @Builder
 public record MemberSearchResponse (
-        Long id,
+        Long memberId,
         String nickname,
         String profileImageUrl,
         Long travelDiaryCount,
@@ -14,7 +14,7 @@ public record MemberSearchResponse (
 ) {
     public static MemberSearchResponse of(Long id, MemberProfileResponse profileResponse) {
         return MemberSearchResponse.builder()
-                .id(id)
+                .memberId(id)
                 .nickname(profileResponse.nickname())
                 .profileImageUrl(profileResponse.profileImageUrl())
                 .travelDiaryCount(profileResponse.travelDiaryCount())

--- a/src/main/java/com/traveljournal/domain/search/repository/MemberSearchRepository.java
+++ b/src/main/java/com/traveljournal/domain/search/repository/MemberSearchRepository.java
@@ -1,0 +1,12 @@
+package com.traveljournal.domain.search.repository;
+
+import com.traveljournal.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MemberSearchRepository extends JpaRepository<Member, Long> {
+    Page<Member> findByNicknameContaining(String nickname, Pageable pageable);
+}

--- a/src/main/java/com/traveljournal/domain/search/service/MemberSearchService.java
+++ b/src/main/java/com/traveljournal/domain/search/service/MemberSearchService.java
@@ -21,7 +21,7 @@ public class MemberSearchService {
     @Transactional(readOnly = true)
     public Page<MemberSearchResponse> searchMembers(String keyword, Pageable pageable) {
 
-        if (keyword == null || keyword.trim().isEmpty())
+        if (keyword == null || keyword.isEmpty())
             throw new IllegalArgumentException("검색어는 비어 있을 수 없습니다.");
 
         Page<Member> membersPage = memberSearchRepository.findByNicknameContaining(keyword, pageable);

--- a/src/main/java/com/traveljournal/domain/search/service/MemberSearchService.java
+++ b/src/main/java/com/traveljournal/domain/search/service/MemberSearchService.java
@@ -1,0 +1,36 @@
+package com.traveljournal.domain.search.service;
+
+import com.traveljournal.domain.member.dto.MemberProfileResponse;
+import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.search.dto.MemberSearchResponse;
+import com.traveljournal.domain.search.repository.MemberSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberSearchService {
+
+    private final MemberSearchRepository memberSearchRepository;
+
+    @Transactional(readOnly = true)
+    public Page<MemberSearchResponse> searchMembers(String keyword, Pageable pageable) {
+
+        if (keyword == null || keyword.trim().isEmpty())
+            throw new IllegalArgumentException("검색어는 비어 있을 수 없습니다.");
+
+        Page<Member> membersPage = memberSearchRepository.findByNicknameContaining(keyword, pageable);
+
+        return membersPage.map(member ->
+                MemberSearchResponse.of(
+                        member.getId(),
+                        MemberProfileResponse.of(member) // 여기서 바로 사용!
+                )
+        );
+    }
+}

--- a/src/main/java/com/traveljournal/domain/search/service/MemberSearchService.java
+++ b/src/main/java/com/traveljournal/domain/search/service/MemberSearchService.java
@@ -21,15 +21,12 @@ public class MemberSearchService {
     @Transactional(readOnly = true)
     public Page<MemberSearchResponse> searchMembers(String keyword, Pageable pageable) {
 
-        if (keyword == null || keyword.isEmpty())
-            throw new IllegalArgumentException("검색어는 비어 있을 수 없습니다.");
-
         Page<Member> membersPage = memberSearchRepository.findByNicknameContaining(keyword, pageable);
 
         return membersPage.map(member ->
                 MemberSearchResponse.of(
                         member.getId(),
-                        MemberProfileResponse.of(member) // 여기서 바로 사용!
+                        MemberProfileResponse.of(member)
                 )
         );
     }


### PR DESCRIPTION
## 🔥 해결된 이슈
- Closes #28 

## 📌 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련된 테스트를 추가하거나 기존 테스트를 실행하여 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드를 따랐는지 확인했습니다.
- [x] 배포가 필요한 경우 관련 작업을 완료했습니다. (예: CI/CD 설정, 환경 변수 추가 등)

## ✨ 작업 내용
1. 사용자 닉네임 기반 검색 기능 구현
    - 사용자가 입력한 키워드 기준으로 닉네임이 해당 키워드를 포함하는 사용자 목록을 검색하는 API ( GET /v1/search?keyword=... ) 구현
    - Pageable 을 적용하여 페이징 처리 
    - 응답 데이터에는 memberId, 닉네임 , 프로필 이미지 URL, 작성한 여행 일지 수 , 장소 수 를 포함 ( 피그마 기준으로 데이터 뽑았습니다 )

2. 검색 결과에서 memberId만 넘기고 대시보드 API 호출
    - 검색 API 응답값에 memberId를 포함해 프론트에 전달
    - 프론트에서 해당 memberId로 기존 대시보드 API( /v1/members/{memberId} 호출


## 🚀 추가 설명
1. memberId 만 반환한 이유
    - 대시보드 api 는 이미 존재하므로 , memberId만 넘기고 프론트에서 해당 api 호출하는 방식으로 설계하면 추가 API 없이 효율적으로 처리 가능할 것으로 예상
    - 백엔드에서 불필요한 로직을 줄이고 유지보수를 간소화
    - 데이터가 많아질 수 있는 검색 결과에서 가벼운 응답 구조 유지

2. 한글 검색 인코딩 처리 필요성
    - URL에 한글/특수문자 포함 시 인코딩되지 않으면 서버에서 제대로 처리되지 않는 문제 발생
    - 프론트에서 검색어를 인코딩해 전송함으로써 검색 정확도 확보
    - 프론트에서 검색어 키워드 전달 할 시 url 인코딩 적용 요청 

3. 구조 재사용
    - MemberProfileResponse 활용한 MemberSearchResponse 생성
    - 사용자 프로필 정보는 이미 정의되어 있던 구조를 활용

## 📸 테스트 결과 (스크린샷 혹은 로그)
- 사용자 검색 1 ( 사용자 있는 경우 )
![사용자 검색 1](https://github.com/user-attachments/assets/416a4fd5-58ba-4773-a0f3-61005cd851b5)

- 사용자 검색 2 ( 사용자 있는 경우 )
![사용자 검색 2](https://github.com/user-attachments/assets/17f01ce9-e611-4da2-91e4-468a1694dd6d)

- 사용자 검색 3 ( 사용자 없는 경우 )
![결과 x](https://github.com/user-attachments/assets/28b9981e-bc23-4d0a-9388-17dfec713a08)
