### PR TITLE
[Feature] 여행일지, 플레이스 전체 조회 API 기능 구현, AuthorizationCode 로그인 시 플랫폼 별 분기 설정

### DIFF
--- a/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
@@ -44,7 +44,7 @@ public class AuthController {
 	)
 	@GetMapping("/login/{socialProvider}/callback")
 	public ResponseEntity<LoginResponse> kakaoCallback(
-		@Parameter(description = "카카오에서 반환한 인증 코드")
+		@Parameter(description = "소셜로그인에서 반환한 인증 코드")
 		@RequestParam String code,
 
 		@Parameter(description = "디바이스 ID (선택 사항)")

--- a/src/main/java/com/traveljournal/domain/auth/service/AppleService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/AppleService.java
@@ -34,7 +34,9 @@ import com.traveljournal.domain.auth.dto.apple.AppleTokenResponse;
 import com.traveljournal.domain.auth.util.AppleClient;
 import com.traveljournal.domain.member.dto.TokenInfo;
 import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.entity.Platform;
 import com.traveljournal.domain.member.entity.SocialProvider;
+import com.traveljournal.domain.member.entity.SocialToken;
 import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.member.service.SocialTokenService;
 import com.traveljournal.domain.member.service.TokenService;
@@ -85,7 +87,7 @@ public class AppleService {
 	public LoginCombinedResponse processAppleLoginWithCode(String code, String deviceId, SocialProvider socialProvider,
 		String platform) {
 		// 애플 토큰 획득
-		AppleTokenResponse appleTokenResponse = getAppleToken(code);
+		AppleTokenResponse appleTokenResponse = getAppleToken(code, platform);
 
 		return processAppleLoginWithIdToken(appleTokenResponse.idToken(), deviceId, socialProvider, platform,
 			appleTokenResponse.refreshToken());
@@ -108,17 +110,27 @@ public class AppleService {
 				member.getId(),
 				refreshToken,
 				socialProvider,
-				expiryDate);
+				expiryDate,
+				platform);
 		}
 
 		return createLoginResponse(member, tokenInfo);
 	}
 
 	// 애플 토큰 요청
-	public AppleTokenResponse getAppleToken(String code) {
-		String clientSecret = createClientSecret();
+	public AppleTokenResponse getAppleToken(String code, String platform) {
+
+		String clientId;
+		if ("ios".equals(platform)) {
+			clientId = iosBundleId; // iOS 번들 ID
+		} else if ("android".equals(platform)) {
+			clientId = androidBundleId; // (필요시) 안드로이드 번들 ID
+		} else {
+			clientId = servicesId; // 웹용 Service ID
+		}
+		String clientSecret = createClientSecret(clientId);
 		return appleClient.appleAuth(
-			servicesId,
+			clientId,
 			code,
 			"authorization_code",
 			clientSecret,
@@ -127,7 +139,7 @@ public class AppleService {
 	}
 
 	// JWT 클라이언트 시크릿 생성
-	private String createClientSecret() {
+	private String createClientSecret(String clientId) {
 		Date expirationDate = Date.from(
 			LocalDateTime.now().plusMinutes(5)
 				.atZone(ZoneId.systemDefault())
@@ -141,7 +153,7 @@ public class AppleService {
 			.setIssuedAt(new Date())
 			.setExpiration(expirationDate)
 			.setAudience("https://appleid.apple.com")
-			.setSubject(servicesId)
+			.setSubject(clientId)
 			.signWith(getPrivateKey(), SignatureAlgorithm.ES256)
 			.compact();
 	}
@@ -259,28 +271,40 @@ public class AppleService {
 	 * 4. 사용자 계정에서 애플 연결 정보 삭제
 	 */
 	public void unlinkAppleAccount(Long memberId) {
-		// 회원 정보 조회
-		Member member = memberService.findById(memberId);
-		// 회원의 애플 식별자(sub) 가져오기
-		String appleUserId = member.getProviderId();
+
+		Optional<SocialToken> socialTokenOpt = socialTokenService.getSocialToken(memberId, SocialProvider.APPLE);
+
+		if (socialTokenOpt.isEmpty()) {
+			throw new RuntimeException("애플 소셜 토큰 정보가 없습니다.");
+		}
+
+		SocialToken socialToken = socialTokenOpt.get();
+		String appleUserId = socialToken.getMember().getProviderId();
+		String refreshToken = socialToken.getRefreshToken();
+		Platform platform = socialToken.getPlatform();
 
 		if (appleUserId == null || appleUserId.isEmpty()) {
 			throw new RuntimeException("애플 계정 연결 정보가 없습니다.");
 		}
 
+		String clientId;
+		if (platform == Platform.IOS) {
+			clientId = iosBundleId;
+		}
+		else if (platform == Platform.ANDROID) {
+			clientId = androidBundleId;
+		}
+		else {
+			clientId = servicesId;
+		}
+
 		try {
 			// 클라이언트 시크릿 생성
-			String clientSecret = createClientSecret();
-
-			// 리프레시 토큰 조회 및 처리
-			Optional<String> refreshTokenOpt = socialTokenService.getSocialRefreshToken(memberId, SocialProvider.APPLE);
-
-			if (refreshTokenOpt.isPresent()) {
-				String refreshToken = refreshTokenOpt.get();
+			String clientSecret = createClientSecret(clientId);
 
 				// 애플 서버에 연결 해제 요청
 				appleClient.revokeToken(
-					servicesId,
+					clientId,
 					clientSecret,
 					refreshToken,
 					"refresh_token"
@@ -288,8 +312,6 @@ public class AppleService {
 
 				// 회원 계정에서 애플 연결 정보 삭제
 				memberService.deleteMember(memberId);
-			}
-
 		} catch (Exception e) {
 			throw new RuntimeException("애플 계정 연결 해제 실패: " + e.getMessage(), e);
 		}

--- a/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
@@ -30,7 +30,7 @@ public class AuthService {
 		return switch (socialProvider) {
 			case KAKAO -> kakaoService.processKakaoLoginWithCode(code, deviceId, socialProvider);
 			case APPLE -> appleService.processAppleLoginWithCode(code, deviceId, socialProvider, platform);
-			case GOOGLE -> googleService.processGoogleLoginWithCode(code, deviceId, socialProvider);
+			case GOOGLE -> googleService.processGoogleLoginWithCode(code, deviceId, socialProvider, platform);
 			default -> throw new UnsupportedOperationException("지원되지 않는 소셜 로그인 제공자입니다.");
 		};
 	}
@@ -48,7 +48,7 @@ public class AuthService {
 		return switch (socialProvider) {
 			case KAKAO -> kakaoService.processKakaoLoginWithIdToken(idToken, deviceId, socialProvider);
 			case APPLE -> appleService.processAppleLoginWithIdToken(idToken, deviceId, socialProvider, platform, refreshToken);
-			case GOOGLE -> googleService.processGoogleLoginWithIdToken(idToken, deviceId, socialProvider, refreshToken);
+			case GOOGLE -> googleService.processGoogleLoginWithIdToken(idToken, deviceId, socialProvider, platform, refreshToken);
 			default -> throw new UnsupportedOperationException("지원되지 않는 소셜 로그인 제공자입니다.");
 		};
 	}

--- a/src/main/java/com/traveljournal/domain/auth/service/GoogleService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/GoogleService.java
@@ -1,10 +1,10 @@
 package com.traveljournal.domain.auth.service;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
-import lombok.Value;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import com.traveljournal.domain.auth.dto.LoginCombinedResponse;
 import com.traveljournal.domain.auth.dto.LoginResponse;
@@ -20,10 +20,6 @@ import com.traveljournal.domain.member.service.SocialTokenService;
 import com.traveljournal.domain.member.service.TokenService;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.client.RestTemplate;
-
-import java.time.LocalDateTime;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -37,15 +33,15 @@ public class GoogleService {
 
 
 	public LoginCombinedResponse processGoogleLoginWithCode(String code, String deviceId,
-		SocialProvider socialProvider) {
+		SocialProvider socialProvider, String platform) {
 		// 구글 토큰 획득
 		GoogleTokenResponse googleTokenResponse = googleClient.getGoogleToken(code);
 
-		return processGoogleLoginWithIdToken(googleTokenResponse.id_token(), deviceId, socialProvider, googleTokenResponse.refresh_token());
+		return processGoogleLoginWithIdToken(googleTokenResponse.id_token(), deviceId, socialProvider, googleTokenResponse.refresh_token(), platform);
 	}
 
 	public LoginCombinedResponse processGoogleLoginWithIdToken(String idToken, String deviceId,
-		SocialProvider socialProvider, String refreshToken) {
+		SocialProvider socialProvider, String refreshToken, String platform) {
 		// ID Token 으로 구글 사용자 정보 가져오기
 		GoogleIdTokenInfo googleIdTokenInfo = googleClient.getGoogleMemberInfoFromIdToken(idToken);
 
@@ -61,7 +57,8 @@ public class GoogleService {
 				member.getId(),
 				refreshToken,
 				socialProvider,
-				expiryDate);
+				expiryDate,
+				platform);
 		}
 
 		// 로그인 응답 생성

--- a/src/main/java/com/traveljournal/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/traveljournal/domain/journal/controller/JournalController.java
@@ -32,10 +32,22 @@ public class JournalController {
 		security = @SecurityRequirement(name = "bearer-key")
 	)
 	@GetMapping("/members/{memberId}/journals/region/{regionName}")
-	public ResponseEntity<Page<JournalListResponse>> getJournalsByRegionPaged(
+	public ResponseEntity<Page<JournalListResponse>> findJournalsByRegionPaged(
 		@PathVariable Long memberId,
 		@PathVariable String regionName,
 		@PageableDefault Pageable pageable) {
-		return ApiResponseHandler.getObjectSuccess(journalService.getJournalsByRegionWithPaging(regionName, pageable));
+		return ApiResponseHandler.getObjectSuccess(journalService.findJournalsByRegionWithPaging(regionName, pageable));
+	}
+
+	@Operation(
+		summary = "회원의 전체 여행일지 조회",
+		description = "특정 회원의 전체 여행일지 리스트를 페이징하여 반환합니다.",
+		security = @SecurityRequirement(name = "bearer-key")
+	)
+	@GetMapping("/members/{memberId}/journals")
+	public ResponseEntity<Page<JournalListResponse>> findJournalsByMember(
+		@PathVariable Long memberId,
+		@PageableDefault Pageable pageable) {
+		return ApiResponseHandler.getObjectSuccess(journalService.findAllJournalsByMemberId(pageable));
 	}
 }

--- a/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
+++ b/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.traveljournal.domain.journal.dto.JournalListResponse;
 import com.traveljournal.global.dummy.DummyDataProvider;
@@ -17,12 +18,21 @@ import lombok.RequiredArgsConstructor;
 public class JournalService {
 	private final DummyDataProvider dummyDataProvider;
 
-	public List<JournalListResponse> getJournalsByRegion(String regionName) {
+	@Transactional(readOnly = true)
+	public List<JournalListResponse> findJournalsByRegion(String regionName) {
 		return dummyDataProvider.getDummyJournalsByRegion(regionName);
 	}
 
-	public Page<JournalListResponse> getJournalsByRegionWithPaging(String regionName, Pageable pageable) {
-		List<JournalListResponse> allData = getJournalsByRegion(regionName);
+	@Transactional(readOnly = true)
+	public Page<JournalListResponse> findJournalsByRegionWithPaging(String regionName, Pageable pageable) {
+		List<JournalListResponse> allData = findJournalsByRegion(regionName);
+		return PaginationUtils.getPagedList(allData, pageable);
+	}
+
+	// MemberId추후 구현 필요
+	@Transactional(readOnly = true)
+	public Page<JournalListResponse> findAllJournalsByMemberId(Pageable pageable) {
+		List<JournalListResponse> allData = findJournalsByRegion("all");
 		return PaginationUtils.getPagedList(allData, pageable);
 	}
 }

--- a/src/main/java/com/traveljournal/domain/member/entity/Platform.java
+++ b/src/main/java/com/traveljournal/domain/member/entity/Platform.java
@@ -1,0 +1,7 @@
+package com.traveljournal.domain.member.entity;
+
+public enum Platform {
+	WEB,
+	IOS,
+	ANDROID
+}

--- a/src/main/java/com/traveljournal/domain/member/entity/SocialToken.java
+++ b/src/main/java/com/traveljournal/domain/member/entity/SocialToken.java
@@ -48,20 +48,26 @@ public class SocialToken {
 
 	private LocalDateTime lastUpdatedAt;
 
+	@Enumerated(EnumType.STRING)
+	@Column(length = 20)
+	private Platform platform; // WEB, IOS, ANDROID 등
+
 	@Builder
-	public SocialToken(Member member, String refreshToken, SocialProvider provider, LocalDateTime expiryDate, String providerId) {
+	public SocialToken(Member member, String refreshToken, SocialProvider provider, LocalDateTime expiryDate, String providerId, Platform platform) {
 		this.member = member;
 		this.refreshToken = refreshToken;
 		this.provider = provider;
 		this.expiryDate = expiryDate;
 		this.lastUpdatedAt = LocalDateTime.now();
 		this.providerId = providerId;
+		this.platform = platform;
 	}
 
-	public void updateRefreshToken(String refreshToken, LocalDateTime expiryDate) {
+	public void updateRefreshToken(String refreshToken, LocalDateTime expiryDate, Platform platform) {
 		this.refreshToken = refreshToken;
 		this.expiryDate = expiryDate;
 		this.lastUpdatedAt = LocalDateTime.now();
+		this.platform = platform;
 	}
 
 	public boolean isExpired() {

--- a/src/main/java/com/traveljournal/domain/member/service/SocialTokenService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/SocialTokenService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.entity.Platform;
 import com.traveljournal.domain.member.entity.SocialProvider;
 import com.traveljournal.domain.member.entity.SocialToken;
 import com.traveljournal.domain.member.repository.SocialTokenRepository;
@@ -23,9 +24,10 @@ public class SocialTokenService {
 
 	@Transactional
 	public void saveOrUpdateSocialToken(Long memberId, String refreshToken,
-		SocialProvider provider, LocalDateTime expiryDate) {
+		SocialProvider provider, LocalDateTime expiryDate, String platformString) {
 		Member member = memberService.findById(memberId);
 
+		Platform platform = Platform.valueOf(platformString.toUpperCase());
 		// 기존 토큰이 있는지 확인 후 업데이트 또는 생성
 		Optional<SocialToken> existingToken =
 			socialTokenRepository.findByMemberIdAndProvider(memberId, provider);
@@ -33,7 +35,7 @@ public class SocialTokenService {
 		if (existingToken.isPresent()) {
 			// 기존 토큰 업데이트
 			SocialToken token = existingToken.get();
-			token.updateRefreshToken(refreshToken, expiryDate);
+			token.updateRefreshToken(refreshToken, expiryDate, platform);
 		} else {
 			// 새 토큰 생성
 			SocialToken token = SocialToken.builder()
@@ -42,6 +44,7 @@ public class SocialTokenService {
 				.provider(provider)
 				.expiryDate(expiryDate)
 				.providerId(member.getProviderId())
+				.platform(platform)
 				.build();
 			socialTokenRepository.save(token);
 		}
@@ -55,5 +58,10 @@ public class SocialTokenService {
 		return socialTokenRepository.findByMemberIdAndProvider(memberId, provider)
 			.filter(token -> !token.isExpired())
 			.map(SocialToken::getRefreshToken);
+	}
+
+	public Optional<SocialToken> getSocialToken(Long memberId, SocialProvider provider) {
+		return socialTokenRepository.findByMemberIdAndProvider(memberId, provider)
+			.filter(token -> !token.isExpired());
 	}
 }

--- a/src/main/java/com/traveljournal/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/traveljournal/domain/place/controller/PlaceController.java
@@ -32,10 +32,22 @@ public class PlaceController {
 		security = @SecurityRequirement(name = "bearer-key")
 	)
 	@GetMapping("/members/{memberId}/places/region/{regionName}")
-	public ResponseEntity<Page<PlaceListResponse>> getPlacesByRegionPaged(
+	public ResponseEntity<Page<PlaceListResponse>> findPlacesByRegionPaged(
 		@PathVariable Long memberId,
 		@PathVariable String regionName,
 		@PageableDefault Pageable pageable) {
-		return ApiResponseHandler.getObjectSuccess(placeService.getPlacesByRegionWithPagion(regionName, pageable));
+		return ApiResponseHandler.getObjectSuccess(placeService.findPlacesByRegionWithPagion(regionName, pageable));
+	}
+
+	@Operation(
+		summary = "회원의 전체 플레이스 조회",
+		description = "특정 회원의 전체 플레이스 리스트를 페이징하여 반환합니다.",
+		security = @SecurityRequirement(name = "bearer-key")
+	)
+	@GetMapping("/members/{memberId}/places")
+	public ResponseEntity<Page<PlaceListResponse>> findJournalsByMember(
+		@PathVariable Long memberId,
+		@PageableDefault Pageable pageable) {
+		return ApiResponseHandler.getObjectSuccess(placeService.findAllPlacesByMemberId(pageable));
 	}
 }

--- a/src/main/java/com/traveljournal/domain/place/service/PlaceService.java
+++ b/src/main/java/com/traveljournal/domain/place/service/PlaceService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.traveljournal.domain.place.dto.PlaceListResponse;
 import com.traveljournal.global.dummy.DummyDataProvider;
@@ -18,12 +19,19 @@ public class PlaceService {
 
 	private final DummyDataProvider dummyDataProvider;
 
-	private List<PlaceListResponse> getPlacesByRegion(String regionName) {
+	private List<PlaceListResponse> findPlacesByRegion(String regionName) {
 		return dummyDataProvider.getDummyPlacesByRegion(regionName);
 	}
 
-	public Page<PlaceListResponse> getPlacesByRegionWithPagion(String regionName, Pageable pageable) {
-		List<PlaceListResponse> allData = getPlacesByRegion(regionName);
+	@Transactional(readOnly = true)
+	public Page<PlaceListResponse> findPlacesByRegionWithPagion(String regionName, Pageable pageable) {
+		List<PlaceListResponse> allData = findPlacesByRegion(regionName);
+		return PaginationUtils.getPagedList(allData, pageable);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<PlaceListResponse> findAllPlacesByMemberId(Pageable pageable) {
+		List<PlaceListResponse> allData = findPlacesByRegion("all");
 		return PaginationUtils.getPagedList(allData, pageable);
 	}
 }

--- a/src/main/java/com/traveljournal/global/dummy/DummyDataProvider.java
+++ b/src/main/java/com/traveljournal/global/dummy/DummyDataProvider.java
@@ -14,449 +14,459 @@ public class DummyDataProvider {
 	// 실제 DB 연동 없이 더미데이터 반환
 	public List<JournalListResponse> getDummyJournalsByRegion(String regionName) {
 		List<JournalListResponse> dummyData = new ArrayList<>();
+		if ("all".equalsIgnoreCase(regionName)) {
+			// 모든 지역 더미 데이터 합치기
+			dummyData.addAll(getDummyJournalsByRegion("수도권"));
+			dummyData.addAll(getDummyJournalsByRegion("강원도"));
+			dummyData.addAll(getDummyJournalsByRegion("충청도"));
+			dummyData.addAll(getDummyJournalsByRegion("전라도"));
+			dummyData.addAll(getDummyJournalsByRegion("제주도"));
+		}
 		// 수도권(서울, 경기, 인천) 지역 더미 데이터
-		if ("수도권".equals(regionName)) {
-			dummyData.add(new JournalListResponse(
-				1L,
-				Arrays.asList("서울", "여행", "도심"),
-				"서울 도심 속 힐링 명소 탐방기",
-				2L,
-				3L,
-				"2025.03.15",
-				"2025.03.18"
-			));
+		else {
+			if ("수도권".equals(regionName)) {
+				dummyData.add(new JournalListResponse(
+					1L,
+					Arrays.asList("서울", "여행", "도심"),
+					"서울 도심 속 힐링 명소 탐방기",
+					2L,
+					3L,
+					"2025.03.15",
+					"2025.03.18"
+				));
 
-			dummyData.add(new JournalListResponse(
-				2L,
-				Arrays.asList("경기도", "수원", "화성"),
-				"수원화성 역사 탐방 가족여행",
-				1L,
-				2L,
-				"2025.02.22",
-				"2025.02.24"
-			));
+				dummyData.add(new JournalListResponse(
+					2L,
+					Arrays.asList("경기도", "수원", "화성"),
+					"수원화성 역사 탐방 가족여행",
+					1L,
+					2L,
+					"2025.02.22",
+					"2025.02.24"
+				));
 
-			dummyData.add(new JournalListResponse(
-				3L,
-				Arrays.asList("인천", "송도", "주말여행"),
-				"송도 센트럴파크 데이트 코스",
-				0L,
-				1L,
-				"2025.04.05",
-				"2025.04.05"
-			));
+				dummyData.add(new JournalListResponse(
+					3L,
+					Arrays.asList("인천", "송도", "주말여행"),
+					"송도 센트럴파크 데이트 코스",
+					0L,
+					1L,
+					"2025.04.05",
+					"2025.04.05"
+				));
 
-			dummyData.add(new JournalListResponse(
-				4L,
-				Arrays.asList("서울", "맛집", "카페"),
-				"서울 핫플레이스 카페 투어",
-				1L,
-				2L,
-				"2025.03.08",
-				"2025.03.10"
-			));
+				dummyData.add(new JournalListResponse(
+					4L,
+					Arrays.asList("서울", "맛집", "카페"),
+					"서울 핫플레이스 카페 투어",
+					1L,
+					2L,
+					"2025.03.08",
+					"2025.03.10"
+				));
 
-			dummyData.add(new JournalListResponse(
-				5L,
-				Arrays.asList("경기도", "가평", "자연"),
-				"가평 자연 속 힐링 여행",
-				2L,
-				3L,
-				"2025.01.17",
-				"2025.01.20"
-			));
-		}
+				dummyData.add(new JournalListResponse(
+					5L,
+					Arrays.asList("경기도", "가평", "자연"),
+					"가평 자연 속 힐링 여행",
+					2L,
+					3L,
+					"2025.01.17",
+					"2025.01.20"
+				));
+			}
 
-		// 강원도 지역 더미 데이터
-		else if ("강원도".equals(regionName)) {
-			dummyData.add(new JournalListResponse(
-				6L,
-				Arrays.asList("강원도", "속초", "바다"),
-				"속초 바다와 함께한 겨울 여행",
-				2L,
-				3L,
-				"2025.01.10",
-				"2025.01.13"
-			));
+			// 강원도 지역 더미 데이터
+			else if ("강원도".equals(regionName)) {
+				dummyData.add(new JournalListResponse(
+					6L,
+					Arrays.asList("강원도", "속초", "바다"),
+					"속초 바다와 함께한 겨울 여행",
+					2L,
+					3L,
+					"2025.01.10",
+					"2025.01.13"
+				));
 
-			dummyData.add(new JournalListResponse(
-				7L,
-				Arrays.asList("강원도", "평창", "스키"),
-				"평창 스키장에서의 짜릿한 경험",
-				3L,
-				4L,
-				"2024.12.24",
-				"2024.12.28"
-			));
+				dummyData.add(new JournalListResponse(
+					7L,
+					Arrays.asList("강원도", "평창", "스키"),
+					"평창 스키장에서의 짜릿한 경험",
+					3L,
+					4L,
+					"2024.12.24",
+					"2024.12.28"
+				));
 
-			dummyData.add(new JournalListResponse(
-				8L,
-				Arrays.asList("강원도", "춘천", "닭갈비"),
-				"춘천 맛집 투어와 남이섬 산책",
-				1L,
-				2L,
-				"2025.04.01",
-				"2025.04.03"
-			));
+				dummyData.add(new JournalListResponse(
+					8L,
+					Arrays.asList("강원도", "춘천", "닭갈비"),
+					"춘천 맛집 투어와 남이섬 산책",
+					1L,
+					2L,
+					"2025.04.01",
+					"2025.04.03"
+				));
 
-			dummyData.add(new JournalListResponse(
-				9L,
-				Arrays.asList("강원도", "양양", "서핑"),
-				"양양에서 서핑 배우기",
-				2L,
-				3L,
-				"2025.03.20",
-				"2025.03.23"
-			));
+				dummyData.add(new JournalListResponse(
+					9L,
+					Arrays.asList("강원도", "양양", "서핑"),
+					"양양에서 서핑 배우기",
+					2L,
+					3L,
+					"2025.03.20",
+					"2025.03.23"
+				));
 
-			dummyData.add(new JournalListResponse(
-				10L,
-				Arrays.asList("강원도", "정선", "힐링"),
-				"정선 민둥산 억새풀 여행",
-				1L,
-				2L,
-				"2024.10.15",
-				"2024.10.17"
-			));
-		}
+				dummyData.add(new JournalListResponse(
+					10L,
+					Arrays.asList("강원도", "정선", "힐링"),
+					"정선 민둥산 억새풀 여행",
+					1L,
+					2L,
+					"2024.10.15",
+					"2024.10.17"
+				));
+			}
 
-		// 충청도 지역 더미 데이터
-		else if ("충청도".equals(regionName)) {
-			dummyData.add(new JournalListResponse(
-				11L,
-				Arrays.asList("충청도", "대전", "과학관"),
-				"대전 국립중앙과학관 탐방기",
-				1L,
-				2L,
-				"2025.02.08",
-				"2025.02.10"
-			));
+			// 충청도 지역 더미 데이터
+			else if ("충청도".equals(regionName)) {
+				dummyData.add(new JournalListResponse(
+					11L,
+					Arrays.asList("충청도", "대전", "과학관"),
+					"대전 국립중앙과학관 탐방기",
+					1L,
+					2L,
+					"2025.02.08",
+					"2025.02.10"
+				));
 
-			dummyData.add(new JournalListResponse(
-				12L,
-				Arrays.asList("충청도", "공주", "역사"),
-				"공주 백제문화제와 역사 여행",
-				2L,
-				3L,
-				"2024.09.25",
-				"2024.09.28"
-			));
+				dummyData.add(new JournalListResponse(
+					12L,
+					Arrays.asList("충청도", "공주", "역사"),
+					"공주 백제문화제와 역사 여행",
+					2L,
+					3L,
+					"2024.09.25",
+					"2024.09.28"
+				));
 
-			dummyData.add(new JournalListResponse(
-				13L,
-				Arrays.asList("충청도", "천안", "독립기념관"),
-				"천안 독립기념관 역사 탐방",
-				0L,
-				1L,
-				"2025.03.01",
-				"2025.03.01"
-			));
+				dummyData.add(new JournalListResponse(
+					13L,
+					Arrays.asList("충청도", "천안", "독립기념관"),
+					"천안 독립기념관 역사 탐방",
+					0L,
+					1L,
+					"2025.03.01",
+					"2025.03.01"
+				));
 
-			dummyData.add(new JournalListResponse(
-				14L,
-				Arrays.asList("충청도", "보령", "머드축제"),
-				"보령 머드축제 즐기기",
-				3L,
-				4L,
-				"2024.07.15",
-				"2024.07.19"
-			));
+				dummyData.add(new JournalListResponse(
+					14L,
+					Arrays.asList("충청도", "보령", "머드축제"),
+					"보령 머드축제 즐기기",
+					3L,
+					4L,
+					"2024.07.15",
+					"2024.07.19"
+				));
 
-			dummyData.add(new JournalListResponse(
-				15L,
-				Arrays.asList("충청도", "단양", "도담삼봉"),
-				"단양 8경 투어와 패러글라이딩",
-				2L,
-				3L,
-				"2025.04.05",
-				"2025.04.08"
-			));
-		}
+				dummyData.add(new JournalListResponse(
+					15L,
+					Arrays.asList("충청도", "단양", "도담삼봉"),
+					"단양 8경 투어와 패러글라이딩",
+					2L,
+					3L,
+					"2025.04.05",
+					"2025.04.08"
+				));
+			}
 
-		// 전라도 지역 더미 데이터
-		else if ("전라도".equals(regionName)) {
-			dummyData.add(new JournalListResponse(
-				21L,
-				Arrays.asList("전라도", "광주", "맛집"),
-				"광주 맛집 투어와 문화 체험",
-				2L,
-				3L,
-				"2025.03.10",
-				"2025.03.13"
-			));
+			// 전라도 지역 더미 데이터
+			else if ("전라도".equals(regionName)) {
+				dummyData.add(new JournalListResponse(
+					21L,
+					Arrays.asList("전라도", "광주", "맛집"),
+					"광주 맛집 투어와 문화 체험",
+					2L,
+					3L,
+					"2025.03.10",
+					"2025.03.13"
+				));
 
-			dummyData.add(new JournalListResponse(
-				22L,
-				Arrays.asList("전라도", "전주", "한옥마을"),
-				"전주 한옥마을 한복 체험",
-				1L,
-				2L,
-				"2025.02.15",
-				"2025.02.17"
-			));
+				dummyData.add(new JournalListResponse(
+					22L,
+					Arrays.asList("전라도", "전주", "한옥마을"),
+					"전주 한옥마을 한복 체험",
+					1L,
+					2L,
+					"2025.02.15",
+					"2025.02.17"
+				));
 
-			dummyData.add(new JournalListResponse(
-				23L,
-				Arrays.asList("전라도", "여수", "밤바다"),
-				"여수 밤바다 로맨틱 여행",
-				2L,
-				3L,
-				"2025.01.20",
-				"2025.01.23"
-			));
+				dummyData.add(new JournalListResponse(
+					23L,
+					Arrays.asList("전라도", "여수", "밤바다"),
+					"여수 밤바다 로맨틱 여행",
+					2L,
+					3L,
+					"2025.01.20",
+					"2025.01.23"
+				));
 
-			dummyData.add(new JournalListResponse(
-				24L,
-				Arrays.asList("전라도", "순천", "순천만"),
-				"순천만 습지와 순천만국가정원",
-				1L,
-				2L,
-				"2025.04.08",
-				"2025.04.10"
-			));
+				dummyData.add(new JournalListResponse(
+					24L,
+					Arrays.asList("전라도", "순천", "순천만"),
+					"순천만 습지와 순천만국가정원",
+					1L,
+					2L,
+					"2025.04.08",
+					"2025.04.10"
+				));
 
-			dummyData.add(new JournalListResponse(
-				25L,
-				Arrays.asList("전라도", "담양", "죽녹원"),
-				"담양 죽녹원과 메타세쿼이아길",
-				0L,
-				1L,
-				"2024.11.09",
-				"2024.11.09"
-			));
-		}
+				dummyData.add(new JournalListResponse(
+					25L,
+					Arrays.asList("전라도", "담양", "죽녹원"),
+					"담양 죽녹원과 메타세쿼이아길",
+					0L,
+					1L,
+					"2024.11.09",
+					"2024.11.09"
+				));
+			}
 
-		// 제주도 지역 더미 데이터
-		else if ("제주도".equals(regionName)) {
-			dummyData.add(new JournalListResponse(
-				26L,
-				Arrays.asList("제주도", "성산일출봉", "우도"),
-				"제주도 동쪽 여행 코스",
-				3L,
-				4L,
-				"2025.03.25",
-				"2025.03.29"
-			));
+			// 제주도 지역 더미 데이터
+			else if ("제주도".equals(regionName)) {
+				dummyData.add(new JournalListResponse(
+					26L,
+					Arrays.asList("제주도", "성산일출봉", "우도"),
+					"제주도 동쪽 여행 코스",
+					3L,
+					4L,
+					"2025.03.25",
+					"2025.03.29"
+				));
 
-			dummyData.add(new JournalListResponse(
-				27L,
-				Arrays.asList("제주도", "한라산", "등산"),
-				"한라산 등반과 오름 투어",
-				4L,
-				5L,
-				"2024.10.10",
-				"2024.10.15"
-			));
+				dummyData.add(new JournalListResponse(
+					27L,
+					Arrays.asList("제주도", "한라산", "등산"),
+					"한라산 등반과 오름 투어",
+					4L,
+					5L,
+					"2024.10.10",
+					"2024.10.15"
+				));
 
-			dummyData.add(new JournalListResponse(
-				28L,
-				Arrays.asList("제주도", "서귀포", "카페"),
-				"서귀포 해안도로 카페 투어",
-				2L,
-				3L,
-				"2025.02.20",
-				"2025.02.23"
-			));
+				dummyData.add(new JournalListResponse(
+					28L,
+					Arrays.asList("제주도", "서귀포", "카페"),
+					"서귀포 해안도로 카페 투어",
+					2L,
+					3L,
+					"2025.02.20",
+					"2025.02.23"
+				));
 
-			dummyData.add(new JournalListResponse(
-				29L,
-				Arrays.asList("제주도", "맛집", "흑돼지"),
-				"제주 맛집 탐방과 흑돼지 먹방",
-				3L,
-				4L,
-				"2025.01.05",
-				"2025.01.09"
-			));
+				dummyData.add(new JournalListResponse(
+					29L,
+					Arrays.asList("제주도", "맛집", "흑돼지"),
+					"제주 맛집 탐방과 흑돼지 먹방",
+					3L,
+					4L,
+					"2025.01.05",
+					"2025.01.09"
+				));
 
-			dummyData.add(new JournalListResponse(
-				30L,
-				Arrays.asList("제주도", "올레길", "힐링"),
-				"제주 올레길 걷기 여행",
-				5L,
-				6L,
-				"2025.04.01",
-				"2025.04.07"
-			));
+				dummyData.add(new JournalListResponse(
+					30L,
+					Arrays.asList("제주도", "올레길", "힐링"),
+					"제주 올레길 걷기 여행",
+					5L,
+					6L,
+					"2025.04.01",
+					"2025.04.07"
+				));
 
-			dummyData.add(new JournalListResponse(
-				31L,
-				Arrays.asList("제주도", "중문", "해변"),
-				"중문 해변에서의 여름 휴가",
-				3L,
-				4L,
-				"2025.07.15",
-				"2025.07.19"
-			));
+				dummyData.add(new JournalListResponse(
+					31L,
+					Arrays.asList("제주도", "중문", "해변"),
+					"중문 해변에서의 여름 휴가",
+					3L,
+					4L,
+					"2025.07.15",
+					"2025.07.19"
+				));
 
-			dummyData.add(new JournalListResponse(
-				32L,
-				Arrays.asList("제주도", "애월", "카페"),
-				"애월 해안도로 카페 투어",
-				2L,
-				3L,
-				"2025.05.10",
-				"2025.05.13"
-			));
+				dummyData.add(new JournalListResponse(
+					32L,
+					Arrays.asList("제주도", "애월", "카페"),
+					"애월 해안도로 카페 투어",
+					2L,
+					3L,
+					"2025.05.10",
+					"2025.05.13"
+				));
 
-			dummyData.add(new JournalListResponse(
-				33L,
-				Arrays.asList("제주도", "협재", "해수욕장"),
-				"에메랄드빛 협재해수욕장 여행",
-				2L,
-				3L,
-				"2025.08.01",
-				"2025.08.04"
-			));
+				dummyData.add(new JournalListResponse(
+					33L,
+					Arrays.asList("제주도", "협재", "해수욕장"),
+					"에메랄드빛 협재해수욕장 여행",
+					2L,
+					3L,
+					"2025.08.01",
+					"2025.08.04"
+				));
 
-			dummyData.add(new JournalListResponse(
-				34L,
-				Arrays.asList("제주도", "한림", "수목원"),
-				"한림공원과 협재해변 당일치기",
-				0L,
-				1L,
-				"2025.06.15",
-				"2025.06.15"
-			));
+				dummyData.add(new JournalListResponse(
+					34L,
+					Arrays.asList("제주도", "한림", "수목원"),
+					"한림공원과 협재해변 당일치기",
+					0L,
+					1L,
+					"2025.06.15",
+					"2025.06.15"
+				));
 
-			dummyData.add(new JournalListResponse(
-				35L,
-				Arrays.asList("제주도", "비자림", "산책"),
-				"비자림 숲길 산책과 힐링",
-				1L,
-				2L,
-				"2025.09.20",
-				"2025.09.22"
-			));
+				dummyData.add(new JournalListResponse(
+					35L,
+					Arrays.asList("제주도", "비자림", "산책"),
+					"비자림 숲길 산책과 힐링",
+					1L,
+					2L,
+					"2025.09.20",
+					"2025.09.22"
+				));
 
-			dummyData.add(new JournalListResponse(
-				36L,
-				Arrays.asList("제주도", "만장굴", "탐험"),
-				"만장굴 탐험과 김녕 해변",
-				1L,
-				2L,
-				"2025.04.15",
-				"2025.04.17"
-			));
+				dummyData.add(new JournalListResponse(
+					36L,
+					Arrays.asList("제주도", "만장굴", "탐험"),
+					"만장굴 탐험과 김녕 해변",
+					1L,
+					2L,
+					"2025.04.15",
+					"2025.04.17"
+				));
 
-			dummyData.add(new JournalListResponse(
-				37L,
-				Arrays.asList("제주도", "마라도", "최남단"),
-				"대한민국 최남단 마라도 여행",
-				2L,
-				3L,
-				"2025.05.25",
-				"2025.05.28"
-			));
+				dummyData.add(new JournalListResponse(
+					37L,
+					Arrays.asList("제주도", "마라도", "최남단"),
+					"대한민국 최남단 마라도 여행",
+					2L,
+					3L,
+					"2025.05.25",
+					"2025.05.28"
+				));
 
-			dummyData.add(new JournalListResponse(
-				38L,
-				Arrays.asList("제주도", "천지연폭포", "야경"),
-				"천지연폭포 야경과 서귀포 맛집",
-				2L,
-				3L,
-				"2025.02.10",
-				"2025.02.13"
-			));
+				dummyData.add(new JournalListResponse(
+					38L,
+					Arrays.asList("제주도", "천지연폭포", "야경"),
+					"천지연폭포 야경과 서귀포 맛집",
+					2L,
+					3L,
+					"2025.02.10",
+					"2025.02.13"
+				));
 
-			dummyData.add(new JournalListResponse(
-				39L,
-				Arrays.asList("제주도", "섭지코지", "드라마"),
-				"드라마 촬영지 섭지코지 투어",
-				1L,
-				2L,
-				"2025.03.05",
-				"2025.03.07"
-			));
+				dummyData.add(new JournalListResponse(
+					39L,
+					Arrays.asList("제주도", "섭지코지", "드라마"),
+					"드라마 촬영지 섭지코지 투어",
+					1L,
+					2L,
+					"2025.03.05",
+					"2025.03.07"
+				));
 
-			dummyData.add(new JournalListResponse(
-				40L,
-				Arrays.asList("제주도", "카멜리아힐", "꽃"),
-				"카멜리아힐 동백꽃 구경",
-				1L,
-				2L,
-				"2025.01.15",
-				"2025.01.17"
-			));
+				dummyData.add(new JournalListResponse(
+					40L,
+					Arrays.asList("제주도", "카멜리아힐", "꽃"),
+					"카멜리아힐 동백꽃 구경",
+					1L,
+					2L,
+					"2025.01.15",
+					"2025.01.17"
+				));
 
-			dummyData.add(new JournalListResponse(
-				41L,
-				Arrays.asList("제주도", "사려니숲길", "트레킹"),
-				"사려니숲길 트레킹과 치유",
-				2L,
-				3L,
-				"2025.06.05",
-				"2025.06.08"
-			));
+				dummyData.add(new JournalListResponse(
+					41L,
+					Arrays.asList("제주도", "사려니숲길", "트레킹"),
+					"사려니숲길 트레킹과 치유",
+					2L,
+					3L,
+					"2025.06.05",
+					"2025.06.08"
+				));
 
-			dummyData.add(new JournalListResponse(
-				42L,
-				Arrays.asList("제주도", "쇠소깍", "카약"),
-				"쇠소깍 카약 체험과 주상절리",
-				1L,
-				2L,
-				"2025.07.25",
-				"2025.07.27"
-			));
+				dummyData.add(new JournalListResponse(
+					42L,
+					Arrays.asList("제주도", "쇠소깍", "카약"),
+					"쇠소깍 카약 체험과 주상절리",
+					1L,
+					2L,
+					"2025.07.25",
+					"2025.07.27"
+				));
 
-			dummyData.add(new JournalListResponse(
-				43L,
-				Arrays.asList("제주도", "오설록", "녹차"),
-				"오설록 녹차밭과 이니스프리",
-				1L,
-				2L,
-				"2025.04.20",
-				"2025.04.22"
-			));
+				dummyData.add(new JournalListResponse(
+					43L,
+					Arrays.asList("제주도", "오설록", "녹차"),
+					"오설록 녹차밭과 이니스프리",
+					1L,
+					2L,
+					"2025.04.20",
+					"2025.04.22"
+				));
 
-			dummyData.add(new JournalListResponse(
-				44L,
-				Arrays.asList("제주도", "아쿠아플라넷", "수족관"),
-				"아쿠아플라넷 제주 가족 나들이",
-				2L,
-				3L,
-				"2025.08.15",
-				"2025.08.18"
-			));
+				dummyData.add(new JournalListResponse(
+					44L,
+					Arrays.asList("제주도", "아쿠아플라넷", "수족관"),
+					"아쿠아플라넷 제주 가족 나들이",
+					2L,
+					3L,
+					"2025.08.15",
+					"2025.08.18"
+				));
 
-			dummyData.add(new JournalListResponse(
-				45L,
-				Arrays.asList("제주도", "용두암", "일출"),
-				"용두암에서 본 제주 일출",
-				1L,
-				2L,
-				"2025.01.01",
-				"2025.01.03"
-			));
+				dummyData.add(new JournalListResponse(
+					45L,
+					Arrays.asList("제주도", "용두암", "일출"),
+					"용두암에서 본 제주 일출",
+					1L,
+					2L,
+					"2025.01.01",
+					"2025.01.03"
+				));
 
-			dummyData.add(new JournalListResponse(
-				46L,
-				Arrays.asList("제주도", "우도", "자전거"),
-				"우도 자전거 일주 여행",
-				1L,
-				2L,
-				"2025.05.05",
-				"2025.05.07"
-			));
+				dummyData.add(new JournalListResponse(
+					46L,
+					Arrays.asList("제주도", "우도", "자전거"),
+					"우도 자전거 일주 여행",
+					1L,
+					2L,
+					"2025.05.05",
+					"2025.05.07"
+				));
 
-			dummyData.add(new JournalListResponse(
-				47L,
-				Arrays.asList("제주도", "함덕", "해수욕장"),
-				"함덕 해수욕장 서핑 체험",
-				2L,
-				3L,
-				"2025.07.05",
-				"2025.07.08"
-			));
+				dummyData.add(new JournalListResponse(
+					47L,
+					Arrays.asList("제주도", "함덕", "해수욕장"),
+					"함덕 해수욕장 서핑 체험",
+					2L,
+					3L,
+					"2025.07.05",
+					"2025.07.08"
+				));
 
-			dummyData.add(new JournalListResponse(
-				48L,
-				Arrays.asList("제주도", "산방산", "산책"),
-				"산방산과 용머리해안 트레킹",
-				1L,
-				2L,
-				"2025.09.10",
-				"2025.09.12"
-			));
+				dummyData.add(new JournalListResponse(
+					48L,
+					Arrays.asList("제주도", "산방산", "산책"),
+					"산방산과 용머리해안 트레킹",
+					1L,
+					2L,
+					"2025.09.10",
+					"2025.09.12"
+				));
+			}
 		}
 
 		return dummyData;
@@ -466,8 +476,16 @@ public class DummyDataProvider {
 		List<PlaceListResponse> dummyData = new ArrayList<>();
 		String imageUrl = "https://search.pstatic.net/common/?src=http%3A%2F%2Fblogfiles.naver.net%2FMjAyNTAzMjFfMTEw%2FMDAxNzQyNTU5MjY0OTkz.US8DxCfatYon23fMlPjPlqGIvpK8Zd8SIP3BuNFyGmUg.LUZS2bZBQ1aJuHyVI52EjhzHykDFewCj4mpJCeoV0G0g.JPEG%2F2025%25BA%25A2%25B2%25C9%25B0%25B3%25C8%25AD%25BD%25C3%25B1%25E2IMG_2503-009.JPG&type=sc960_832";
 
+		if("all".equalsIgnoreCase(regionName)) {
+			dummyData.addAll(getDummyPlacesByRegion("수도권"));
+			dummyData.addAll(getDummyPlacesByRegion("강원도"));
+			dummyData.addAll(getDummyPlacesByRegion("충청도"));
+			dummyData.addAll(getDummyPlacesByRegion("전라도"));
+			dummyData.addAll(getDummyPlacesByRegion("제주도"));
+		}
 		// 수도권(서울, 경기, 인천) 지역 더미 데이터
-		if ("수도권".equals(regionName)) {
+		else {
+			if ("수도권".equals(regionName)) {
 			dummyData.add(new PlaceListResponse(
 				1L,
 				"서울 타워",
@@ -712,7 +730,7 @@ public class DummyDataProvider {
 				imageUrl
 			));
 		}
-
+	}
 		return dummyData;
 	}
 }


### PR DESCRIPTION
## 🔥 해결된 이슈
- Closes #32 
- TJFE-149

## 📌 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련된 테스트를 추가하거나 기존 테스트를 실행하여 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드를 따랐는지 확인했습니다.
- [x] 배포가 필요한 경우 관련 작업을 완료했습니다. (예: CI/CD 설정, 환경 변수 추가 등)

## ✨ 작업 내용
- AuthorizationCode 플랫폼 분기 설정
> 시크릿 서명 코드로 인하여 애플뿐만 아니라 구글도 적용
차후 카카오 또한 통일성을 위해 refresh_token의 플랫폼 설정 필요 (사용하지는 않음 - 카카오, 구글)
- 더미데이터 전체 조회(여행일지, 플레이스)
> get으로 되어있던 메서드명도 추가로 수정(여행일지, 플레이스 둘다 없을 수 있기 때문에)

## 🚀 추가 설명
> socialToken entity에 platform이 추가되었습니다.
애플로그인의 경우 refresh_token이 web, ios, android가 다르기 때문에 애플 토큰 서버에서 refresh_token이 유효하지 않다고 반환하는 문제가 있어서 위와 같이 추가하여 해결
애플 로그인 web은 테스트하였으나 앱단에서의 테스트는 해당 팀원의 테스트 필요합니다.
## 📸 테스트 결과 (스크린샷 혹은 로그)
> [스크린샷 혹은 테스트 정상 확인 로그를 첨부해주세요.]
![image](https://github.com/user-attachments/assets/fa36084f-3b27-46a9-82f4-ae52eae8aa36)
![image](https://github.com/user-attachments/assets/d3ff51bf-5c9c-4cb1-8543-d30c7c8c3e4d)
