### PR TITLE
[Feature] Follow 기능 구현

### DIFF
--- a/src/main/java/com/traveljournal/domain/member/controller/FollowController.java
+++ b/src/main/java/com/traveljournal/domain/member/controller/FollowController.java
@@ -1,0 +1,90 @@
+package com.traveljournal.domain.member.controller;
+
+import com.traveljournal.domain.member.dto.MemberProfileResponse;
+import com.traveljournal.domain.member.service.FollowService;
+import com.traveljournal.global.data.ApiResponseHandler;
+import com.traveljournal.global.security.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/v1/follow")
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final FollowService followService;
+
+    @Operation(
+            summary = "Member Follow",
+            description = "현재 로그인한 회원이 특정 회원을 팔로우합니다.",
+            security = @SecurityRequirement(name = "bearer-key")
+    )
+    @PostMapping("/{memberId}")
+    public ResponseEntity<?> followMember(@PathVariable("memberId") Long memberId) {
+        Long currentMemberId = SecurityUtil.getCurrentMemberId();
+        followService.follow(currentMemberId, memberId);
+        return ApiResponseHandler.onSuccess("팔로우 성공");
+    }
+
+    @Operation(
+            summary = "Member UnFollow",
+            description = "현재 로그인한 회원이 특정 회원을 언팔로우합니다.",
+            security = @SecurityRequirement(name = "bearer-key")
+    )
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<?> unfollowMember(@PathVariable("memberId") Long memberId) {
+        Long currentMemberId = SecurityUtil.getCurrentMemberId();
+        followService.unfollow(currentMemberId, memberId);
+        return ApiResponseHandler.deletedSuccess("언팔로우 성공");
+    }
+
+    @Operation(
+            summary = "특정 회원의 팔로잉 목록",
+            description = "해당 회원이 팔로우하고 있는 사람들의 리스트를 조회합니다.",
+            security = @SecurityRequirement(name = "bearer-key")
+    )
+
+    @GetMapping("/{memberId}/followings")
+    public ResponseEntity<?> getFollowings(@PathVariable("memberId") Long memberId) {
+        return ApiResponseHandler.getObjectSuccess(followService.getFollowings(memberId));
+    }
+
+    @Operation(
+            summary = "특정 회원의 팔로워 목록",
+            description = "해당 회원을 팔로우하고 있는 사람들의 리스트를 조회합니다.",
+            security = @SecurityRequirement(name = "bearer-key")
+    )
+    @GetMapping("/{memberId}/followers")
+    public ResponseEntity<?> getFollowers(@PathVariable Long memberId) {
+        return ApiResponseHandler.getObjectSuccess(followService.getFollowers(memberId));
+    }
+
+    @Operation(
+            summary = "팔로우 수 및 팔로워 수 조회",
+            description = "특정 회원의 팔로우/팔로워 수를 반환합니다.",
+            security = @SecurityRequirement(name = "bearer-key")
+    )
+    @GetMapping("/{memberId}/count")
+    public ResponseEntity<Map<String, Long>> getFollowCounts(@PathVariable Long memberId) {
+        long followers = followService.getFollowerCount(memberId);
+        long followings = followService.getFollowingCount(memberId);
+        return ResponseEntity.ok(Map.of(
+                "followers", followers,
+                "followings", followings
+        ));
+    }
+
+    @Operation(summary = "팔로우 여부 확인", description = "현재 로그인한 회원이 해당 회원을 팔로우하고 있는지 여부를 반환합니다.", security = @SecurityRequirement(name = "bearer-key"))
+    @GetMapping("/{memberId}/is-following")
+    public ResponseEntity<Boolean> isFollowing(@PathVariable Long memberId) {
+        Long currentMemberId = SecurityUtil.getCurrentMemberId();
+        return ApiResponseHandler.getObjectSuccess(followService.isFollowing(currentMemberId, memberId));
+    }
+}
+

--- a/src/main/java/com/traveljournal/domain/member/controller/FollowController.java
+++ b/src/main/java/com/traveljournal/domain/member/controller/FollowController.java
@@ -1,6 +1,7 @@
 package com.traveljournal.domain.member.controller;
 
 import com.traveljournal.domain.member.dto.FollowCountResponse;
+import com.traveljournal.domain.member.dto.FollowProfileResponse;
 import com.traveljournal.domain.member.dto.MemberProfileResponse;
 import com.traveljournal.domain.member.service.FollowService;
 import com.traveljournal.global.data.ApiResponseHandler;
@@ -8,6 +9,8 @@ import com.traveljournal.global.security.util.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -52,8 +55,9 @@ public class FollowController {
     )
 
     @GetMapping("/{memberId}/followings")
-    public ResponseEntity<?> getFollowings(@PathVariable("memberId") Long memberId) {
-        return ApiResponseHandler.getObjectSuccess(followService.getFollowings(memberId));
+    public ResponseEntity<Page<FollowProfileResponse>> getFollowings(@PathVariable("memberId") Long memberId,
+                                                                     Pageable pageable) {
+        return ApiResponseHandler.getObjectSuccess(followService.findFollowings(memberId, pageable));
     }
 
     @Operation(
@@ -62,8 +66,9 @@ public class FollowController {
             security = @SecurityRequirement(name = "bearer-key")
     )
     @GetMapping("/{memberId}/followers")
-    public ResponseEntity<?> getFollowers(@PathVariable Long memberId) {
-        return ApiResponseHandler.getObjectSuccess(followService.getFollowers(memberId));
+    public ResponseEntity<Page<FollowProfileResponse>> getFollowers(@PathVariable Long memberId,
+                                                                    Pageable pageable) {
+        return ApiResponseHandler.getObjectSuccess(followService.findFollowers(memberId, pageable));
     }
 
     @Operation(
@@ -72,7 +77,7 @@ public class FollowController {
             security = @SecurityRequirement(name = "bearer-key")
     )
     @GetMapping("/{memberId}/count")
-    public ResponseEntity<?> getFollowCounts(@PathVariable Long memberId) {
+    public ResponseEntity<FollowCountResponse> getFollowCounts(@PathVariable Long memberId) {
         long followers = followService.getFollowerCount(memberId);
         long followings = followService.getFollowingCount(memberId);
         return ApiResponseHandler.getObjectSuccess(

--- a/src/main/java/com/traveljournal/domain/member/controller/FollowController.java
+++ b/src/main/java/com/traveljournal/domain/member/controller/FollowController.java
@@ -1,5 +1,6 @@
 package com.traveljournal.domain.member.controller;
 
+import com.traveljournal.domain.member.dto.FollowCountResponse;
 import com.traveljournal.domain.member.dto.MemberProfileResponse;
 import com.traveljournal.domain.member.service.FollowService;
 import com.traveljournal.global.data.ApiResponseHandler;
@@ -71,16 +72,18 @@ public class FollowController {
             security = @SecurityRequirement(name = "bearer-key")
     )
     @GetMapping("/{memberId}/count")
-    public ResponseEntity<Map<String, Long>> getFollowCounts(@PathVariable Long memberId) {
+    public ResponseEntity<?> getFollowCounts(@PathVariable Long memberId) {
         long followers = followService.getFollowerCount(memberId);
         long followings = followService.getFollowingCount(memberId);
-        return ResponseEntity.ok(Map.of(
-                "followers", followers,
-                "followings", followings
-        ));
+        return ApiResponseHandler.getObjectSuccess(
+                new FollowCountResponse(followers, followings)
+        );
     }
 
-    @Operation(summary = "팔로우 여부 확인", description = "현재 로그인한 회원이 해당 회원을 팔로우하고 있는지 여부를 반환합니다.", security = @SecurityRequirement(name = "bearer-key"))
+    @Operation(
+            summary = "팔로우 여부 확인",
+            description = "현재 로그인한 회원이 해당 회원을 팔로우하고 있는지 여부를 반환합니다.",
+            security = @SecurityRequirement(name = "bearer-key"))
     @GetMapping("/{memberId}/is-following")
     public ResponseEntity<Boolean> isFollowing(@PathVariable Long memberId) {
         Long currentMemberId = SecurityUtil.getCurrentMemberId();

--- a/src/main/java/com/traveljournal/domain/member/dto/FollowCountResponse.java
+++ b/src/main/java/com/traveljournal/domain/member/dto/FollowCountResponse.java
@@ -1,0 +1,4 @@
+package com.traveljournal.domain.member.dto;
+
+public record FollowCountResponse (Long followers, Long followings){
+}

--- a/src/main/java/com/traveljournal/domain/member/dto/FollowProfileResponse.java
+++ b/src/main/java/com/traveljournal/domain/member/dto/FollowProfileResponse.java
@@ -8,8 +8,6 @@ public record FollowProfileResponse(
         Long memberId,
         String nickname,
         String profileImageUrl,
-        Long followerCount,
-        Long followingCount,
         Long travelDiaryCount,
         Long placesCount
 ) {
@@ -18,8 +16,6 @@ public record FollowProfileResponse(
                 .memberId(member.getId())
                 .nickname(member.getNickname())
                 .profileImageUrl(member.getProfileImageUrl())
-                .followerCount((long) member.getFollowings().size())
-                .followingCount((long) member.getFollowers().size())
                 .travelDiaryCount(36L)
                 .placesCount(88L)
                 .build();

--- a/src/main/java/com/traveljournal/domain/member/dto/FollowProfileResponse.java
+++ b/src/main/java/com/traveljournal/domain/member/dto/FollowProfileResponse.java
@@ -1,0 +1,27 @@
+package com.traveljournal.domain.member.dto;
+
+import com.traveljournal.domain.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record FollowProfileResponse(
+        Long memberId,
+        String nickname,
+        String profileImageUrl,
+        Long followerCount,
+        Long followingCount,
+        Long travelDiaryCount,
+        Long placesCount
+) {
+    public static FollowProfileResponse of(Member member) {
+        return FollowProfileResponse.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileImageUrl())
+                .followerCount((long) member.getFollowings().size())
+                .followingCount((long) member.getFollowers().size())
+                .travelDiaryCount(36L)
+                .placesCount(88L)
+                .build();
+    }
+}

--- a/src/main/java/com/traveljournal/domain/member/entity/Follow.java
+++ b/src/main/java/com/traveljournal/domain/member/entity/Follow.java
@@ -15,14 +15,12 @@ public class Follow {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "from_user")
+    @JoinColumn(name = "from_member")
     // fromUser 나를 / 팔로우를 요청하는 USER
-    private Member fromUser;
+    private Member fromMember;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "to_user")
+    @JoinColumn(name = "to_member")
     // toUser 내가 / 팔로우를 요청받은 USER
-    private Member toUser;
-
-
+    private Member toMember;
 }

--- a/src/main/java/com/traveljournal/domain/member/entity/Follow.java
+++ b/src/main/java/com/traveljournal/domain/member/entity/Follow.java
@@ -1,0 +1,28 @@
+package com.traveljournal.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Follow {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_user")
+    // fromUser 나를 / 팔로우를 요청하는 USER
+    private Member fromUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_user")
+    // toUser 내가 / 팔로우를 요청받은 USER
+    private Member toUser;
+
+
+}

--- a/src/main/java/com/traveljournal/domain/member/entity/Member.java
+++ b/src/main/java/com/traveljournal/domain/member/entity/Member.java
@@ -1,16 +1,9 @@
 package com.traveljournal.domain.member.entity;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -46,6 +39,12 @@ public class Member {
 	private SocialProvider socialProvider;
 
 	private Boolean isFirstLogin = true;
+
+	@OneToMany(mappedBy = "fromUser", fetch = FetchType.LAZY)
+	private List<Follow> followings;
+
+	@OneToMany(mappedBy = "toUser", fetch = FetchType.LAZY)
+	private List<Follow> followers;
 
 	@PrePersist
 	public void prePersist() {

--- a/src/main/java/com/traveljournal/domain/member/entity/Member.java
+++ b/src/main/java/com/traveljournal/domain/member/entity/Member.java
@@ -40,10 +40,10 @@ public class Member {
 
 	private Boolean isFirstLogin = true;
 
-	@OneToMany(mappedBy = "fromUser", fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "fromMember", fetch = FetchType.LAZY)
 	private List<Follow> followings;
 
-	@OneToMany(mappedBy = "toUser", fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "toMember", fetch = FetchType.LAZY)
 	private List<Follow> followers;
 
 	@PrePersist

--- a/src/main/java/com/traveljournal/domain/member/repository/FollowRepository.java
+++ b/src/main/java/com/traveljournal/domain/member/repository/FollowRepository.java
@@ -1,6 +1,7 @@
 package com.traveljournal.domain.member.repository;
 
 import com.traveljournal.domain.member.entity.Follow;
+import com.traveljournal.domain.member.entity.FollowStatus;
 import com.traveljournal.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,9 +13,9 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     List<Follow> findByFromUser(Member fromUser);
     // 나를 팔로우 하는 사람들
     List<Follow> findByToUser(Member toUser);
-
     long countByFromUser(Member fromUser);
     long countByToUser(Member toUser);
-    boolean existsByFromUserAndToUser(Member fromUser, Member toUser);
-    void deleteByFromUserAndToUser(Member fromUser, Member toUser);
+    boolean existsByFromUserIdAndToUserId(Long fromUserId, Long toUserId);
+    void deleteByFromUserIdAndToUserId(Long fromUser, Long toUser);
+
 }

--- a/src/main/java/com/traveljournal/domain/member/repository/FollowRepository.java
+++ b/src/main/java/com/traveljournal/domain/member/repository/FollowRepository.java
@@ -1,8 +1,9 @@
 package com.traveljournal.domain.member.repository;
 
 import com.traveljournal.domain.member.entity.Follow;
-import com.traveljournal.domain.member.entity.FollowStatus;
 import com.traveljournal.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,12 +11,11 @@ import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     // 내가 팔로우 하는 사람들
-    List<Follow> findByFromUser(Member fromUser);
+    Page<Follow> findByFromMember(Member fromMember, Pageable pageable);
     // 나를 팔로우 하는 사람들
-    List<Follow> findByToUser(Member toUser);
-    long countByFromUser(Member fromUser);
-    long countByToUser(Member toUser);
-    boolean existsByFromUserIdAndToUserId(Long fromUserId, Long toUserId);
-    void deleteByFromUserIdAndToUserId(Long fromUser, Long toUser);
-
+    Page<Follow> findByToMember(Member toMember, Pageable pageable);
+    long countByFromMember(Member fromMember);
+    long countByToMember(Member toMember);
+    boolean existsByFromMemberIdAndToMemberId(Long fromfromUserMemberId, Long toMemberId);
+    void deleteByFromMemberIdAndToMemberId(Long fromMember, Long toMember);
 }

--- a/src/main/java/com/traveljournal/domain/member/repository/FollowRepository.java
+++ b/src/main/java/com/traveljournal/domain/member/repository/FollowRepository.java
@@ -1,0 +1,20 @@
+package com.traveljournal.domain.member.repository;
+
+import com.traveljournal.domain.member.entity.Follow;
+import com.traveljournal.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    // 내가 팔로우 하는 사람들
+    List<Follow> findByFromUser(Member fromUser);
+    // 나를 팔로우 하는 사람들
+    List<Follow> findByToUser(Member toUser);
+
+    long countByFromUser(Member fromUser);
+    long countByToUser(Member toUser);
+    boolean existsByFromUserAndToUser(Member fromUser, Member toUser);
+    void deleteByFromUserAndToUser(Member fromUser, Member toUser);
+}

--- a/src/main/java/com/traveljournal/domain/member/service/FollowService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/FollowService.java
@@ -1,0 +1,87 @@
+package com.traveljournal.domain.member.service;
+
+import com.traveljournal.domain.member.dto.MemberProfileResponse;
+import com.traveljournal.domain.member.entity.Follow;
+import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.repository.FollowRepository;
+import com.traveljournal.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+    private final FollowRepository followRepository;
+    private final MemberService memberService;
+
+    @Transactional
+    public void follow(Long fromUserId, Long toUserId) {
+        if (fromUserId.equals(toUserId)) {
+            throw new RuntimeException("자신을 팔로우 할 수 없습니다.");
+        }
+
+        Member fromUser = memberService.findById(fromUserId);
+        Member toUser = memberService.findById(toUserId);
+
+        if(followRepository.existsByFromUserAndToUser(fromUser, toUser)) {
+            throw new RuntimeException("이미 팔로우한 사용자입니다.");
+        }
+
+        Follow follow = Follow.builder()
+                .fromUser(fromUser)
+                .toUser(toUser)
+                .build();
+
+        followRepository.save(follow);
+    }
+
+    @Transactional
+    public void unfollow(Long fromUserId, Long toUserId) {
+        Member fromUser = memberService.findById(fromUserId);
+        Member toUser = memberService.findById(toUserId);
+
+        followRepository.deleteByFromUserAndToUser(fromUser, toUser);
+    }
+
+    // 내가 팔로우한 사람들
+    @Transactional(readOnly = true)
+    public List<MemberProfileResponse> getFollowings(Long memberId) {
+        Member member = memberService.findById(memberId);
+        return followRepository.findByFromUser(member).stream()
+                .map(follow -> MemberProfileResponse.of(follow.getToUser()))
+                .collect(Collectors.toList());
+    }
+
+    // 나를 팔로우하는 사람들
+    @Transactional(readOnly = true)
+    public List<MemberProfileResponse> getFollowers(Long memberId) {
+        Member member = memberService.findById(memberId);
+        return followRepository.findByToUser(member).stream()
+                .map(follow -> MemberProfileResponse.of(follow.getFromUser()))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public long getFollowerCount(Long memberId) {
+        Member member = memberService.findById(memberId);
+        return followRepository.countByToUser(member);
+    }
+
+    @Transactional(readOnly = true)
+    public long getFollowingCount(Long memberId) {
+        Member member = memberService.findById(memberId);
+        return followRepository.countByFromUser(member);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isFollowing(Long followerId, Long followingId) {
+        Member follower = memberService.findById(followerId);
+        Member following = memberService.findById(followingId);
+        return followRepository.existsByFromUserAndToUser(follower, following);
+    }
+
+}

--- a/src/main/java/com/traveljournal/domain/member/service/FollowService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/FollowService.java
@@ -17,6 +17,9 @@ import java.util.stream.Collectors;
 public class FollowService {
     private final FollowRepository followRepository;
     private final MemberService memberService;
+    private Member getMemberById(Long id) {
+        return memberService.findById(id);
+    }
 
     @Transactional
     public void follow(Long fromUserId, Long toUserId) {
@@ -24,12 +27,11 @@ public class FollowService {
             throw new RuntimeException("자신을 팔로우 할 수 없습니다.");
         }
 
-        Member fromUser = memberService.findById(fromUserId);
-        Member toUser = memberService.findById(toUserId);
-
-        if(followRepository.existsByFromUserAndToUser(fromUser, toUser)) {
+        if(followRepository.existsByFromUserIdAndToUserId(fromUserId, toUserId)) {
             throw new RuntimeException("이미 팔로우한 사용자입니다.");
         }
+        Member fromUser = getMemberById(fromUserId);
+        Member toUser = getMemberById(toUserId);
 
         Follow follow = Follow.builder()
                 .fromUser(fromUser)
@@ -41,16 +43,13 @@ public class FollowService {
 
     @Transactional
     public void unfollow(Long fromUserId, Long toUserId) {
-        Member fromUser = memberService.findById(fromUserId);
-        Member toUser = memberService.findById(toUserId);
-
-        followRepository.deleteByFromUserAndToUser(fromUser, toUser);
+        followRepository.deleteByFromUserIdAndToUserId(fromUserId, toUserId);
     }
 
     // 내가 팔로우한 사람들
     @Transactional(readOnly = true)
     public List<MemberProfileResponse> getFollowings(Long memberId) {
-        Member member = memberService.findById(memberId);
+        Member member = getMemberById(memberId);
         return followRepository.findByFromUser(member).stream()
                 .map(follow -> MemberProfileResponse.of(follow.getToUser()))
                 .collect(Collectors.toList());
@@ -59,7 +58,7 @@ public class FollowService {
     // 나를 팔로우하는 사람들
     @Transactional(readOnly = true)
     public List<MemberProfileResponse> getFollowers(Long memberId) {
-        Member member = memberService.findById(memberId);
+        Member member = getMemberById(memberId);
         return followRepository.findByToUser(member).stream()
                 .map(follow -> MemberProfileResponse.of(follow.getFromUser()))
                 .collect(Collectors.toList());
@@ -67,21 +66,19 @@ public class FollowService {
 
     @Transactional(readOnly = true)
     public long getFollowerCount(Long memberId) {
-        Member member = memberService.findById(memberId);
+        Member member = getMemberById(memberId);
         return followRepository.countByToUser(member);
     }
 
     @Transactional(readOnly = true)
     public long getFollowingCount(Long memberId) {
-        Member member = memberService.findById(memberId);
+        Member member = getMemberById(memberId);
         return followRepository.countByFromUser(member);
     }
 
     @Transactional(readOnly = true)
     public boolean isFollowing(Long followerId, Long followingId) {
-        Member follower = memberService.findById(followerId);
-        Member following = memberService.findById(followingId);
-        return followRepository.existsByFromUserAndToUser(follower, following);
+        return followRepository.existsByFromUserIdAndToUserId(followerId, followingId);
     }
 
 }

--- a/src/main/java/com/traveljournal/domain/member/service/FollowService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/FollowService.java
@@ -1,11 +1,12 @@
 package com.traveljournal.domain.member.service;
 
-import com.traveljournal.domain.member.dto.MemberProfileResponse;
+import com.traveljournal.domain.member.dto.FollowProfileResponse;
 import com.traveljournal.domain.member.entity.Follow;
 import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.member.repository.FollowRepository;
-import com.traveljournal.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,68 +18,63 @@ import java.util.stream.Collectors;
 public class FollowService {
     private final FollowRepository followRepository;
     private final MemberService memberService;
-    private Member getMemberById(Long id) {
-        return memberService.findById(id);
-    }
-
+    private Member findMemberById(Long id) {return memberService.findById(id);}
     @Transactional
-    public void follow(Long fromUserId, Long toUserId) {
-        if (fromUserId.equals(toUserId)) {
+    public void follow(Long fromMemberId, Long toMemberId) {
+        if (fromMemberId.equals(toMemberId)) {
             throw new RuntimeException("자신을 팔로우 할 수 없습니다.");
         }
 
-        if(followRepository.existsByFromUserIdAndToUserId(fromUserId, toUserId)) {
+        if(followRepository.existsByFromMemberIdAndToMemberId(fromMemberId, toMemberId)) {
             throw new RuntimeException("이미 팔로우한 사용자입니다.");
         }
-        Member fromUser = getMemberById(fromUserId);
-        Member toUser = getMemberById(toUserId);
+        Member fromMember = findMemberById(fromMemberId);
+        Member toMember = findMemberById(toMemberId);
 
         Follow follow = Follow.builder()
-                .fromUser(fromUser)
-                .toUser(toUser)
+                .fromMember(fromMember)
+                .toMember(toMember)
                 .build();
 
         followRepository.save(follow);
     }
 
     @Transactional
-    public void unfollow(Long fromUserId, Long toUserId) {
-        followRepository.deleteByFromUserIdAndToUserId(fromUserId, toUserId);
+    public void unfollow(Long fromMemberId, Long toMemberId) {
+        followRepository.deleteByFromMemberIdAndToMemberId(fromMemberId, toMemberId);
     }
 
     // 내가 팔로우한 사람들
     @Transactional(readOnly = true)
-    public List<MemberProfileResponse> getFollowings(Long memberId) {
-        Member member = getMemberById(memberId);
-        return followRepository.findByFromUser(member).stream()
-                .map(follow -> MemberProfileResponse.of(follow.getToUser()))
-                .collect(Collectors.toList());
+    public Page<FollowProfileResponse> findFollowings(Long memberId, Pageable pageable) {
+        Member member = findMemberById(memberId);
+        return followRepository.findByFromMember(member, pageable)
+                .map(follow -> FollowProfileResponse.of(follow.getToMember()));
     }
 
     // 나를 팔로우하는 사람들
     @Transactional(readOnly = true)
-    public List<MemberProfileResponse> getFollowers(Long memberId) {
-        Member member = getMemberById(memberId);
-        return followRepository.findByToUser(member).stream()
-                .map(follow -> MemberProfileResponse.of(follow.getFromUser()))
-                .collect(Collectors.toList());
+    public Page<FollowProfileResponse> findFollowers(Long memberId, Pageable pageable) {
+        Member member = findMemberById(memberId);
+        return followRepository.findByToMember(member, pageable)
+                .map(follow -> FollowProfileResponse.of(follow.getFromMember()));
     }
 
     @Transactional(readOnly = true)
     public long getFollowerCount(Long memberId) {
-        Member member = getMemberById(memberId);
-        return followRepository.countByToUser(member);
+        Member member = findMemberById(memberId);
+        return followRepository.countByToMember(member);
     }
 
     @Transactional(readOnly = true)
     public long getFollowingCount(Long memberId) {
-        Member member = getMemberById(memberId);
-        return followRepository.countByFromUser(member);
+        Member member = findMemberById(memberId);
+        return followRepository.countByFromMember(member);
     }
 
     @Transactional(readOnly = true)
     public boolean isFollowing(Long followerId, Long followingId) {
-        return followRepository.existsByFromUserIdAndToUserId(followerId, followingId);
+        return followRepository.existsByFromMemberIdAndToMemberId(followerId, followingId);
     }
 
 }


### PR DESCRIPTION
## 🔥 해결된 이슈
- Closes #34 

## 📌 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련된 테스트를 추가하거나 기존 테스트를 실행하여 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드를 따랐는지 확인했습니다.
- [x] 배포가 필요한 경우 관련 작업을 완료했습니다. (예: CI/CD 설정, 환경 변수 추가 등)

## ✨ 작업 내용
- 로그인한 사용자가 다른 회원을 팔로우/언팔로우할 수 있는 API 
    - POST /v1/follow/{memberId}: 팔로우
    - DELETE /v1/follow/{memberId}: 언팔로우

- 특정 회원의 팔로잉/팔로워 목록 조회 API 구현
    - GET /v1/follow/{memberId}/followings: 팔로잉 목록
    - GET /v1/follow/{memberId}/followers: 팔로워 목록

- 특정 회원의 팔로우 수 / 팔로워 수 조회 API 
    - GET /v1/follow/{memberId}/count

- 현재 로그인한 사용자가 특정 회원을 팔로우하고 있는지 여부를 반환하는 API 
    - GET /v1/follow/{memberId}/is-following
    - true : 팔로우 O
    - false : 팔로우 X 
  
## 🚀 추가 설명
- API  요청 시 Authorization: Bearer <token> 헤더 필수
- 향후 비공개 계정에 대한 팔로우 요청 기능이 필요할 수 도 있을 거 같아 구현 예정

## 📸 테스트 결과 (스크린샷 혹은 로그)
- memberId가 본인이면 401 오류 
![본인=본인](https://github.com/user-attachments/assets/28b08149-db00-40cc-97d7-11e736e89559)
- 로그인한 유저가 특정 회원 Follow 성공 시
![본인=회원2](https://github.com/user-attachments/assets/4287ffaa-081d-4ab9-8632-39e6617ac990)
- 로그인한 유저의 팔로워 목록
![팔로워](https://github.com/user-attachments/assets/335b3621-0909-4086-b65d-2f03e1b037be)
- 로그인한 유저의 팔로잉 목록
![팔로잉](https://github.com/user-attachments/assets/efe520b8-1721-4d41-a2d4-7acadc71cae0)
- 로그인한 유저의 팔로워 ,팔로잉 수 
![count](https://github.com/user-attachments/assets/7347fb82-c957-451e-b958-735d5562cb41)
- 특정 회원과의 팔로우 여부 
![팔로우여부](https://github.com/user-attachments/assets/bfda8abd-ce32-43ae-86cb-9f5fa7e44bae)
- UnFollow
![언팔](https://github.com/user-attachments/assets/cbbba07c-dad9-4774-ba48-719179e8c8bf)
- 언팔로우 후 팔로우 여부
![언팔 후 팔로우여부](https://github.com/user-attachments/assets/fc2ea398-62cf-4660-945f-d1625d6b7263)
- 특정 회원 팔로워 목록
![특정회원팔로워](https://github.com/user-attachments/assets/53a02a27-2378-4513-b7a6-3e06cef8618c)
