### PR TITLE
[Refactor] Auth도메인 관련 Swagger 문서 정리 & 토큰 예외처리 & Kakao, Apple, Google 예외처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     asciidoctorExtension 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 
     // 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
@@ -54,9 +54,19 @@ public class AuthController {
 			content = @Content(
 				mediaType = "text/plain",
 				examples = {
-					@ExampleObject(name = "지원하지 않는 소셜 로그인 제공자", value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"),
-					@ExampleObject(name = "유효하지 않은 Authorization Header", description = "Bearer이 빠져있거나 잘못되었을 경우",value = "유효한 Authorization 헤더가 필요합니다. : authorizationHeader"),
-					@ExampleObject(name = "인증 코드가 비어있거나 null", description = "비어있을때 예시", value = "인증 코드 : ")
+					@ExampleObject(
+						name = "지원하지 않는 소셜 로그인 제공자",
+						value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"
+					),
+					@ExampleObject(
+						name = "유효하지 않은 Authorization Header",
+						description = "Bearer이 빠져있거나 잘못되었을 경우",
+						value = "유효한 Authorization 헤더가 필요합니다. : authorizationHeader"
+					),
+					@ExampleObject(
+						name = "인증 코드가 비어있거나 null",
+						description = "비어있을때 예시",
+						value = "인증 코드 : ")
 				}
 			)
 		),
@@ -66,8 +76,14 @@ public class AuthController {
 			content = @Content(
 				mediaType = "text/plain",
 				examples = {
-					@ExampleObject(name = "id_token 비어있거나 null", value = "id_token이 비어있거나 null입니다. : idToken"),
-					@ExampleObject(name = "id_token 정보 중 sub가 존재하지 않을때", value = "id_token 정보중 회원번호(sub)가 없습니다.")
+					@ExampleObject(
+						name = "id_token 비어있거나 null",
+						value = "id_token이 비어있거나 null입니다. : idToken"
+					),
+					@ExampleObject(
+						name = "id_token 정보 중 sub가 존재하지 않을때",
+						value = "id_token 정보중 회원번호(sub)가 없습니다."
+					)
 				}
 			)
 		),
@@ -77,8 +93,15 @@ public class AuthController {
 			content = @Content(
 				mediaType = "text/plain",
 				examples = {
-					@ExampleObject(name = "토큰 발급 실패", description = "유효하지 않은 토큰일 경우 토큰 서버에서 HTTP 400 상태코드와 함께 발급 실패", value = "카카오 토큰 발급에 실패했습니다: 400  on POST request for \"https://kauth.kakao.com/oauth/token\": \"{\"error\":\"invalid_grant\",\"error_description\":\"authorization code not found for code=eee\",\"error_code\":\"KOE320\"}\""),
-					@ExampleObject(name = "id_token 파싱 실패", value = "id_token 파싱에 실패했습니다 / 파싱 실패 메시지")
+					@ExampleObject(
+						name = "토큰 발급 실패",
+						description = "유효하지 않은 토큰일 경우 토큰 서버에서 HTTP 400 상태코드와 함께 발급 실패",
+						value = "카카오 토큰 발급에 실패했습니다: 400  on POST request for \"https://kauth.kakao.com/oauth/token\": \"{\"error\":\"invalid_grant\",\"error_description\":\"authorization code not found for code=eee\",\"error_code\":\"KOE320\"}\""
+					),
+					@ExampleObject(
+						name = "id_token 파싱 실패",
+						value = "id_token 파싱에 실패했습니다 : Invalid JWS header: Invalid JSON: Unexpected End Of File position 62: null"
+					)
 				}
 			)
 		)
@@ -120,8 +143,15 @@ public class AuthController {
 			content = @Content(
 				mediaType = "text/plain",
 				examples = {
-					@ExampleObject(name = "지원하지 않는 소셜 로그인 제공자", value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"),
-					@ExampleObject(name = "유효하지 않은 Authorization Header", description = "Bearer이 빠져있거나 잘못되었을 경우",value = "유효한 Authorization 헤더가 필요합니다. : authorizationHeader")
+					@ExampleObject(
+						name = "지원하지 않는 소셜 로그인 제공자",
+						value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"
+					),
+					@ExampleObject(
+						name = "유효하지 않은 Authorization Header",
+						description = "Bearer이 빠져있거나 잘못되었을 경우",
+						value = "유효한 Authorization 헤더가 필요합니다. : authorizationHeader"
+					)
 				}
 			)
 		),
@@ -131,8 +161,14 @@ public class AuthController {
 			content = @Content(
 				mediaType = "text/plain",
 				examples = {
-					@ExampleObject(name = "id_token 비어있거나 null", value = "id_token이 비어있거나 null입니다. : idToken"),
-					@ExampleObject(name = "id_token 정보 중 sub가 존재하지 않을때", value = "id_token 정보중 회원번호(sub)가 없습니다.")
+					@ExampleObject(
+						name = "id_token 비어있거나 null",
+						value = "id_token이 비어있거나 null입니다. : idToken"
+					),
+					@ExampleObject(
+						name = "id_token 정보 중 sub가 존재하지 않을때",
+						value = "id_token 정보중 회원번호(sub)가 없습니다."
+					)
 				}
 			)
 		),
@@ -142,8 +178,15 @@ public class AuthController {
 			content = @Content(
 				mediaType = "text/plain",
 				examples = {
-					@ExampleObject(name = "토큰 발급 실패", description = "유효하지 않은 토큰일 경우 토큰 서버에서 HTTP 400 상태코드와 함께 발급 실패", value = "카카오 토큰 발급에 실패했습니다: 400  on POST request for \"https://kauth.kakao.com/oauth/token\": \"{\"error\":\"invalid_grant\",\"error_description\":\"authorization code not found for code=eee\",\"error_code\":\"KOE320\"}\""),
-					@ExampleObject(name = "id_token 파싱 실패", value = "id_token 파싱에 실패했습니다 / 파싱 실패 메시지")
+					@ExampleObject(
+						name = "토큰 발급 실패",
+						description = "유효하지 않은 토큰일 경우 토큰 서버에서 HTTP 400 상태코드와 함께 발급 실패",
+						value = "카카오 토큰 발급에 실패했습니다: 400  on POST request for \"https://kauth.kakao.com/oauth/token\": \"{\"error\":\"invalid_grant\",\"error_description\":\"authorization code not found for code=eee\",\"error_code\":\"KOE320\"}\""
+					),
+					@ExampleObject(
+						name = "id_token 파싱 실패",
+						value = "id_token 파싱에 실패했습니다 : Invalid JWS header: Invalid JSON: Unexpected End Of File position 62: null"
+					)
 				}
 			)
 		)
@@ -186,6 +229,17 @@ public class AuthController {
 		summary = "Logout",
 		description = "특정 장치에서 로그아웃을 처리하고 해당 장치의 토큰을 삭제합니다.",
 		security = @SecurityRequirement(name = "bearer-key")
+	)
+	@ApiResponse(
+		responseCode = "200",
+		description = "성공",
+		content = @Content(
+			mediaType = "text/plain",
+			examples = @ExampleObject(
+				name = "로그아웃 성공",
+				value = "로그아웃 성공"
+			)
+		)
 	)
 	@PostMapping("/logout")
 	public ResponseEntity<?> logout(

--- a/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
@@ -20,6 +20,10 @@ import com.traveljournal.global.security.util.SecurityUtil;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -42,8 +46,44 @@ public class AuthController {
 		summary = "Social Login callback",
 		description = "인증 코드를 받아 로그인/회원가입 후 헤더에 액세스 토큰을 발급합니다."
 	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "성공"),
+		@ApiResponse(
+			responseCode = "400",
+			description = "잘못된 요청",
+			content = @Content(
+				mediaType = "text/plain",
+				examples = {
+					@ExampleObject(name = "지원하지 않는 소셜 로그인 제공자", value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"),
+					@ExampleObject(name = "인증 코드가 비어있거나 null", description = "비어있을때 예시", value = "인증 코드 : ")
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "401",
+			description = "인증 정보가 잘못되었거나, 인증이 필요한 상황",
+			content = @Content(
+				mediaType = "text/plain",
+				examples = {
+					@ExampleObject(name = "id_token 비어있거나 null", value = "id_token이 비어있거나 null입니다. : idToken"),
+					@ExampleObject(name = "id_token 정보 중 sub가 존재하지 않을때", value = "id_token 정보중 회원번호(sub)가 없습니다.")
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "503",
+			description = "외부 API 요청 실패",
+			content = @Content(
+				mediaType = "text/plain",
+				examples = {
+					@ExampleObject(name = "토큰 발급 실패", description = "유효하지 않은 토큰일 경우 토큰 서버에서 HTTP 400 상태코드와 함께 발급 실패", value = "카카오 토큰 발급에 실패했습니다: 400  on POST request for \"https://kauth.kakao.com/oauth/token\": \"{\"error\":\"invalid_grant\",\"error_description\":\"authorization code not found for code=eee\",\"error_code\":\"KOE320\"}\""),
+					@ExampleObject(name = "id_token 파싱 실패", value = "id_token 파싱에 실패했습니다 / 파싱 실패 메시지")
+				}
+			)
+		)
+	})
 	@GetMapping("/login/{socialProvider}/callback")
-	public ResponseEntity<LoginResponse> kakaoCallback(
+	public ResponseEntity<LoginResponse> socialCallback(
 		@Parameter(description = "소셜로그인에서 반환한 인증 코드")
 		@RequestParam String code,
 
@@ -72,7 +112,7 @@ public class AuthController {
 			<br> X-Platform 헤더에 (web, ios, android)를 포함해야 합니다."""
 	)
 	@PostMapping("/login/{socialProvider}/id-token")
-	public ResponseEntity<LoginResponse> kakaoLoginWithIdToken(
+	public ResponseEntity<LoginResponse> socialLoginWithIdToken(
 		@Parameter(description = "소셜에서 반환한 id_Token을 헤더에 담아주세요. Bearer 필요")
 		@RequestHeader("Authorization") String authorizationHeader,
 
@@ -87,7 +127,7 @@ public class AuthController {
 
 		@Parameter(description = "소셜 로그인 Refresh_token, Bearer 필요")
 		@RequestHeader(value = "X-Refresh-Token", required = false) String refreshToken
-		) {
+	) {
 		SocialProvider socialProviderEnum = EnumUtils.toSocialProvider(socialProvider);
 
 		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithIdToken(

--- a/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
@@ -112,6 +112,42 @@ public class AuthController {
 			ID 토큰을 이용한 로그인. Bearer 토큰을 Authorization 헤더에 포함해야 합니다.
 			<br> X-Platform 헤더에 (web, ios, android)를 포함해야 합니다."""
 	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "성공"),
+		@ApiResponse(
+			responseCode = "400",
+			description = "잘못된 요청",
+			content = @Content(
+				mediaType = "text/plain",
+				examples = {
+					@ExampleObject(name = "지원하지 않는 소셜 로그인 제공자", value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"),
+					@ExampleObject(name = "유효하지 않은 Authorization Header", description = "Bearer이 빠져있거나 잘못되었을 경우",value = "유효한 Authorization 헤더가 필요합니다. : authorizationHeader")
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "401",
+			description = "인증 정보가 잘못되었거나, 인증이 필요한 상황",
+			content = @Content(
+				mediaType = "text/plain",
+				examples = {
+					@ExampleObject(name = "id_token 비어있거나 null", value = "id_token이 비어있거나 null입니다. : idToken"),
+					@ExampleObject(name = "id_token 정보 중 sub가 존재하지 않을때", value = "id_token 정보중 회원번호(sub)가 없습니다.")
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "503",
+			description = "외부 API 요청 실패",
+			content = @Content(
+				mediaType = "text/plain",
+				examples = {
+					@ExampleObject(name = "토큰 발급 실패", description = "유효하지 않은 토큰일 경우 토큰 서버에서 HTTP 400 상태코드와 함께 발급 실패", value = "카카오 토큰 발급에 실패했습니다: 400  on POST request for \"https://kauth.kakao.com/oauth/token\": \"{\"error\":\"invalid_grant\",\"error_description\":\"authorization code not found for code=eee\",\"error_code\":\"KOE320\"}\""),
+					@ExampleObject(name = "id_token 파싱 실패", value = "id_token 파싱에 실패했습니다 / 파싱 실패 메시지")
+				}
+			)
+		)
+	})
 	@PostMapping("/login/{socialProvider}/id-token")
 	public ResponseEntity<LoginResponse> socialLoginWithIdToken(
 		@Parameter(description = "소셜에서 반환한 id_Token을 헤더에 담아주세요. Bearer 필요")

--- a/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
@@ -230,17 +230,33 @@ public class AuthController {
 		description = "특정 장치에서 로그아웃을 처리하고 해당 장치의 토큰을 삭제합니다.",
 		security = @SecurityRequirement(name = "bearer-key")
 	)
-	@ApiResponse(
-		responseCode = "200",
-		description = "성공",
-		content = @Content(
-			mediaType = "text/plain",
-			examples = @ExampleObject(
-				name = "로그아웃 성공",
-				value = "로그아웃 성공"
+	@ApiResponses(
+		{
+			@ApiResponse(
+				responseCode = "200",
+				description = "성공",
+				content = @Content(
+					mediaType = "text/plain",
+					examples = @ExampleObject(
+						name = "로그아웃 성공",
+						value = "로그아웃 성공"
+					)
+				)
+			),
+			@ApiResponse(
+				responseCode = "401",
+				description = "인증 정보가 잘못되었거나, 인증이 필요한 상황",
+				content = @Content(
+					mediaType = "text/plain",
+					examples = {
+						@ExampleObject(
+							name = "올바른 사용자 정보가 아닙니다.",
+							value = "올바른 사용자 정보가 아닙니다."
+						)
+					}
+				)
 			)
-		)
-	)
+		})
 	@PostMapping("/logout")
 	public ResponseEntity<?> logout(
 		@Parameter(description = "로그아웃 할 member의 device_id를 입력해주세요.")
@@ -256,6 +272,89 @@ public class AuthController {
 		description = "특정 회원의 연동을 해제합니다.",
 		security = @SecurityRequirement(name = "bearer-key")
 	)
+	@ApiResponses(
+		{
+			@ApiResponse(
+				responseCode = "200",
+				description = "성공",
+				content = @Content(
+					mediaType = "text/plain",
+					examples = @ExampleObject(
+						name = "연결끊기 성공",
+						value = "연결끊기 성공"
+					)
+				)
+			),
+			@ApiResponse(
+				responseCode = "400",
+				description = "잘못된 요청",
+				content = @Content(
+					mediaType = "text/plain",
+					examples = {
+						@ExampleObject(
+							name = "지원하지 않는 소셜 로그인 제공자",
+							value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"
+						),
+						@ExampleObject(
+							name = "카카오 회원번호가 비어 있습니다.",
+							value = "카카오 회원번호가 비어 있습니다."
+						)
+					}
+				)
+			),
+			@ApiResponse(
+				responseCode = "401",
+				description = "인증 정보가 잘못되었거나, 인증이 필요한 상황",
+				content = @Content(
+					mediaType = "text/plain",
+					examples = {
+						@ExampleObject(
+							name = "올바른 사용자 정보가 아닙니다.",
+							value = "올바른 사용자 정보가 아닙니다."
+						)
+					}
+				)
+			),
+			@ApiResponse(
+				responseCode = "404",
+				description = "리소스가 존재하지 않을때",
+				content = @Content(
+					mediaType = "text/plain",
+					examples = {
+						@ExampleObject(
+							name = "회원을 찾을 수 없습니다.",
+							value = "회원을 찾을 수 없습니다. ID: memberId"
+						)
+					}
+				)
+			),
+			@ApiResponse(
+				responseCode = "503",
+				description = "외부 API 요청 실패",
+				content = @Content(
+					mediaType = "text/plain",
+					examples = {
+						@ExampleObject(
+							name = "카카오 연결 끊기 실패",
+							value = "카카오 연결 끊기에 실패했습니다: e.getMessage()"
+						)
+					}
+				)
+			),
+			@ApiResponse(
+				responseCode = "500",
+				description = "서버 내부 오류",
+				content = @Content(
+					mediaType = "text/plain",
+					examples = {
+						@ExampleObject(
+							name = "회원 삭제 중 오류가 발생했습니다.",
+							value = "회원 삭제 중 오류가 발생했습니다."
+						)
+					}
+				)
+			)
+		})
 	@DeleteMapping("/{socialProvider}/unlink")
 	public ResponseEntity<?> unlinkSocialAccount(
 		@Parameter(description = "소셜로그인 제공자 (kakao, google, apple)")

--- a/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
@@ -55,6 +55,7 @@ public class AuthController {
 				mediaType = "text/plain",
 				examples = {
 					@ExampleObject(name = "지원하지 않는 소셜 로그인 제공자", value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"),
+					@ExampleObject(name = "유효하지 않은 Authorization Header", description = "Bearer이 빠져있거나 잘못되었을 경우",value = "유효한 Authorization 헤더가 필요합니다. : authorizationHeader"),
 					@ExampleObject(name = "인증 코드가 비어있거나 null", description = "비어있을때 예시", value = "인증 코드 : ")
 				}
 			)

--- a/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
@@ -10,22 +10,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.traveljournal.domain.auth.controller.docs.AuthControllerDocs;
 import com.traveljournal.domain.auth.dto.LoginCombinedResponse;
-import com.traveljournal.domain.auth.dto.LoginResponse;
 import com.traveljournal.domain.auth.service.AuthService;
 import com.traveljournal.domain.auth.util.EnumUtils;
 import com.traveljournal.domain.member.entity.SocialProvider;
 import com.traveljournal.global.data.ApiResponseHandler;
 import com.traveljournal.global.security.util.SecurityUtil;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,335 +25,58 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/auth")
-@Tag(name = "Auth API", description = "로그인 및 로그아웃 관련 API")
-public class AuthController {
+public class AuthController implements AuthControllerDocs {
 
 	private final AuthService authService;
 
-	/**
-	 * 로그인 콜백 처리
-	 * 인증 코드를 받아 로그인/회원가입 처리 후 토큰 발급
-	 */
-	@Operation(
-		summary = "Social Login callback",
-		description = "인증 코드를 받아 로그인/회원가입 후 헤더에 액세스 토큰을 발급합니다."
-	)
-	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "성공"),
-		@ApiResponse(
-			responseCode = "400",
-			description = "잘못된 요청",
-			content = @Content(
-				mediaType = "text/plain",
-				examples = {
-					@ExampleObject(
-						name = "지원하지 않는 소셜 로그인 제공자",
-						value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"
-					),
-					@ExampleObject(
-						name = "유효하지 않은 Authorization Header",
-						description = "Bearer이 빠져있거나 잘못되었을 경우",
-						value = "유효한 Authorization 헤더가 필요합니다. : authorizationHeader"
-					),
-					@ExampleObject(
-						name = "인증 코드가 비어있거나 null",
-						description = "비어있을때 예시",
-						value = "인증 코드 : ")
-				}
-			)
-		),
-		@ApiResponse(
-			responseCode = "401",
-			description = "인증 정보가 잘못되었거나, 인증이 필요한 상황",
-			content = @Content(
-				mediaType = "text/plain",
-				examples = {
-					@ExampleObject(
-						name = "id_token 비어있거나 null",
-						value = "id_token이 비어있거나 null입니다. : idToken"
-					),
-					@ExampleObject(
-						name = "id_token 정보 중 sub가 존재하지 않을때",
-						value = "id_token 정보중 회원번호(sub)가 없습니다."
-					)
-				}
-			)
-		),
-		@ApiResponse(
-			responseCode = "503",
-			description = "외부 API 요청 실패",
-			content = @Content(
-				mediaType = "text/plain",
-				examples = {
-					@ExampleObject(
-						name = "토큰 발급 실패",
-						description = "유효하지 않은 토큰일 경우 토큰 서버에서 HTTP 400 상태코드와 함께 발급 실패",
-						value = "카카오 토큰 발급에 실패했습니다: 400  on POST request for \"https://kauth.kakao.com/oauth/token\": \"{\"error\":\"invalid_grant\",\"error_description\":\"authorization code not found for code=eee\",\"error_code\":\"KOE320\"}\""
-					),
-					@ExampleObject(
-						name = "id_token 파싱 실패",
-						value = "id_token 파싱에 실패했습니다 : Invalid JWS header: Invalid JSON: Unexpected End Of File position 62: null"
-					)
-				}
-			)
-		)
-	})
 	@GetMapping("/login/{socialProvider}/callback")
-	public ResponseEntity<LoginResponse> socialCallback(
-		@Parameter(description = "소셜로그인에서 반환한 인증 코드")
+	@Override
+	public ResponseEntity<?> socialCallback(
 		@RequestParam String code,
-
-		@Parameter(description = "디바이스 ID (선택 사항)")
 		@RequestParam(required = false) String deviceId,
-
-		@Parameter(description = "소셜로그인 제공자 (kakao, google, apple)")
 		@PathVariable String socialProvider,
-
-		@Parameter(description = "플랫폼 (web, ios, android)")
 		@RequestHeader(value = "X-Platform", defaultValue = "web") String platform
 	) {
 		SocialProvider socialProviderEnum = EnumUtils.toSocialProvider(socialProvider);
-
-		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithCode(socialProviderEnum, code,
-			deviceId, platform);
-
-		return ApiResponseHandler.accessTokenResponse(loginCombinedResponse.LoginResponse(),
-			loginCombinedResponse.accessToken());
+		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithCode(
+			socialProviderEnum, code, deviceId, platform
+		);
+		return ApiResponseHandler.accessTokenResponse(
+			loginCombinedResponse.LoginResponse(), loginCombinedResponse.accessToken()
+		);
 	}
 
-	@Operation(
-		summary = "Social ID Token Login",
-		description = """
-			ID 토큰을 이용한 로그인. Bearer 토큰을 Authorization 헤더에 포함해야 합니다.
-			<br> X-Platform 헤더에 (web, ios, android)를 포함해야 합니다."""
-	)
-	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "성공"),
-		@ApiResponse(
-			responseCode = "400",
-			description = "잘못된 요청",
-			content = @Content(
-				mediaType = "text/plain",
-				examples = {
-					@ExampleObject(
-						name = "지원하지 않는 소셜 로그인 제공자",
-						value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"
-					),
-					@ExampleObject(
-						name = "유효하지 않은 Authorization Header",
-						description = "Bearer이 빠져있거나 잘못되었을 경우",
-						value = "유효한 Authorization 헤더가 필요합니다. : authorizationHeader"
-					)
-				}
-			)
-		),
-		@ApiResponse(
-			responseCode = "401",
-			description = "인증 정보가 잘못되었거나, 인증이 필요한 상황",
-			content = @Content(
-				mediaType = "text/plain",
-				examples = {
-					@ExampleObject(
-						name = "id_token 비어있거나 null",
-						value = "id_token이 비어있거나 null입니다. : idToken"
-					),
-					@ExampleObject(
-						name = "id_token 정보 중 sub가 존재하지 않을때",
-						value = "id_token 정보중 회원번호(sub)가 없습니다."
-					)
-				}
-			)
-		),
-		@ApiResponse(
-			responseCode = "503",
-			description = "외부 API 요청 실패",
-			content = @Content(
-				mediaType = "text/plain",
-				examples = {
-					@ExampleObject(
-						name = "토큰 발급 실패",
-						description = "유효하지 않은 토큰일 경우 토큰 서버에서 HTTP 400 상태코드와 함께 발급 실패",
-						value = "카카오 토큰 발급에 실패했습니다: 400  on POST request for \"https://kauth.kakao.com/oauth/token\": \"{\"error\":\"invalid_grant\",\"error_description\":\"authorization code not found for code=eee\",\"error_code\":\"KOE320\"}\""
-					),
-					@ExampleObject(
-						name = "id_token 파싱 실패",
-						value = "id_token 파싱에 실패했습니다 : Invalid JWS header: Invalid JSON: Unexpected End Of File position 62: null"
-					)
-				}
-			)
-		)
-	})
 	@PostMapping("/login/{socialProvider}/id-token")
-	public ResponseEntity<LoginResponse> socialLoginWithIdToken(
-		@Parameter(description = "소셜에서 반환한 id_Token을 헤더에 담아주세요. Bearer 필요")
+	@Override
+	public ResponseEntity<?> socialLoginWithIdToken(
 		@RequestHeader("Authorization") String authorizationHeader,
-
-		@Parameter(description = "디바이스 ID (선택 사항)")
 		@RequestParam(required = false) String deviceId,
-
-		@Parameter(description = "소셜로그인 제공자 (kakao, google, apple)")
 		@PathVariable String socialProvider,
-
-		@Parameter(description = "플랫폼 (web, ios, android)")
 		@RequestHeader(value = "X-Platform", defaultValue = "web") String platform,
-
-		@Parameter(description = "소셜 로그인 Refresh_token, Bearer 필요")
 		@RequestHeader(value = "X-Refresh-Token", required = false) String refreshToken
 	) {
 		SocialProvider socialProviderEnum = EnumUtils.toSocialProvider(socialProvider);
-
 		LoginCombinedResponse loginCombinedResponse = authService.handleLoginWithIdToken(
-			socialProviderEnum,
-			authorizationHeader,
-			deviceId,
-			platform,
-			refreshToken);
-
-		return ApiResponseHandler.accessTokenResponse(loginCombinedResponse.LoginResponse(),
-			loginCombinedResponse.accessToken());
+			socialProviderEnum, authorizationHeader, deviceId, platform, refreshToken
+		);
+		return ApiResponseHandler.accessTokenResponse(
+			loginCombinedResponse.LoginResponse(), loginCombinedResponse.accessToken()
+		);
 	}
 
-	/**
-	 * 로그아웃 처리
-	 * 특정 장치에서 로그아웃 시 해당 장치의 토큰 삭제
-	 */
-	@Operation(
-		summary = "Logout",
-		description = "특정 장치에서 로그아웃을 처리하고 해당 장치의 토큰을 삭제합니다.",
-		security = @SecurityRequirement(name = "bearer-key")
-	)
-	@ApiResponses(
-		{
-			@ApiResponse(
-				responseCode = "200",
-				description = "성공",
-				content = @Content(
-					mediaType = "text/plain",
-					examples = @ExampleObject(
-						name = "로그아웃 성공",
-						value = "로그아웃 성공"
-					)
-				)
-			),
-			@ApiResponse(
-				responseCode = "401",
-				description = "인증 정보가 잘못되었거나, 인증이 필요한 상황",
-				content = @Content(
-					mediaType = "text/plain",
-					examples = {
-						@ExampleObject(
-							name = "올바른 사용자 정보가 아닙니다.",
-							value = "올바른 사용자 정보가 아닙니다."
-						)
-					}
-				)
-			)
-		})
 	@PostMapping("/logout")
-	public ResponseEntity<?> logout(
-		@Parameter(description = "로그아웃 할 member의 device_id를 입력해주세요.")
-		@RequestParam String deviceId) {
+	@Override
+	public ResponseEntity<?> logout(@RequestParam String deviceId) {
 		Long memberId = SecurityUtil.getCurrentMemberId();
-
 		authService.logout(memberId, deviceId);
 		return ApiResponseHandler.deletedSuccess("로그아웃 성공");
 	}
 
-	@Operation(
-		summary = "Unlink",
-		description = "특정 회원의 연동을 해제합니다.",
-		security = @SecurityRequirement(name = "bearer-key")
-	)
-	@ApiResponses(
-		{
-			@ApiResponse(
-				responseCode = "200",
-				description = "성공",
-				content = @Content(
-					mediaType = "text/plain",
-					examples = @ExampleObject(
-						name = "연결끊기 성공",
-						value = "연결끊기 성공"
-					)
-				)
-			),
-			@ApiResponse(
-				responseCode = "400",
-				description = "잘못된 요청",
-				content = @Content(
-					mediaType = "text/plain",
-					examples = {
-						@ExampleObject(
-							name = "지원하지 않는 소셜 로그인 제공자",
-							value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"
-						),
-						@ExampleObject(
-							name = "카카오 회원번호가 비어 있습니다.",
-							value = "카카오 회원번호가 비어 있습니다."
-						)
-					}
-				)
-			),
-			@ApiResponse(
-				responseCode = "401",
-				description = "인증 정보가 잘못되었거나, 인증이 필요한 상황",
-				content = @Content(
-					mediaType = "text/plain",
-					examples = {
-						@ExampleObject(
-							name = "올바른 사용자 정보가 아닙니다.",
-							value = "올바른 사용자 정보가 아닙니다."
-						)
-					}
-				)
-			),
-			@ApiResponse(
-				responseCode = "404",
-				description = "리소스가 존재하지 않을때",
-				content = @Content(
-					mediaType = "text/plain",
-					examples = {
-						@ExampleObject(
-							name = "회원을 찾을 수 없습니다.",
-							value = "회원을 찾을 수 없습니다. ID: memberId"
-						)
-					}
-				)
-			),
-			@ApiResponse(
-				responseCode = "503",
-				description = "외부 API 요청 실패",
-				content = @Content(
-					mediaType = "text/plain",
-					examples = {
-						@ExampleObject(
-							name = "카카오 연결 끊기 실패",
-							value = "카카오 연결 끊기에 실패했습니다: e.getMessage()"
-						)
-					}
-				)
-			),
-			@ApiResponse(
-				responseCode = "500",
-				description = "서버 내부 오류",
-				content = @Content(
-					mediaType = "text/plain",
-					examples = {
-						@ExampleObject(
-							name = "회원 삭제 중 오류가 발생했습니다.",
-							value = "회원 삭제 중 오류가 발생했습니다."
-						)
-					}
-				)
-			)
-		})
 	@DeleteMapping("/{socialProvider}/unlink")
-	public ResponseEntity<?> unlinkSocialAccount(
-		@Parameter(description = "소셜로그인 제공자 (kakao, google, apple)")
-		@PathVariable String socialProvider) {
+	@Override
+	public ResponseEntity<?> unlinkSocialAccount(@PathVariable String socialProvider) {
 		Long memberId = SecurityUtil.getCurrentMemberId();
 		SocialProvider socialProviderEnum = EnumUtils.toSocialProvider(socialProvider);
-
 		authService.unlinkSocialAccount(memberId, socialProviderEnum);
 		return ApiResponseHandler.deletedSuccess("연결끊기 성공");
 	}

--- a/src/main/java/com/traveljournal/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/docs/AuthControllerDocs.java
@@ -1,0 +1,180 @@
+package com.traveljournal.domain.auth.controller.docs;
+
+import org.springframework.http.ResponseEntity;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Auth API", description = "로그인 및 로그아웃 관련 API")
+public interface AuthControllerDocs {
+
+	@Operation(
+		summary = "Social Login callback",
+		description = "인증 코드를 받아 로그인/회원가입 후 헤더에 액세스 토큰을 발급합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "성공"),
+		@ApiResponse(
+			responseCode = "400",
+			description = "잘못된 요청",
+			content = @Content(
+				mediaType = "text/plain",
+				examples = {
+					@ExampleObject(name = "지원하지 않는 소셜 로그인 제공자", value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"),
+					@ExampleObject(name = "유효하지 않은 Authorization Header", value = "유효한 Authorization 헤더가 필요합니다. : authorizationHeader"),
+					@ExampleObject(name = "인증 코드가 비어있거나 null", value = "인증 코드 : ")
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "401",
+			description = "인증 정보가 잘못되었거나, 인증이 필요한 상황",
+			content = @Content(
+				mediaType = "text/plain",
+				examples = {
+					@ExampleObject(name = "id_token 비어있거나 null", value = "id_token이 비어있거나 null입니다. : idToken"),
+					@ExampleObject(name = "id_token 정보 중 sub가 존재하지 않을때", value = "id_token 정보중 회원번호(sub)가 없습니다.")
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "503",
+			description = "외부 API 요청 실패",
+			content = @Content(
+				mediaType = "text/plain",
+				examples = {
+					@ExampleObject(name = "토큰 발급 실패", value = "카카오 토큰 발급에 실패했습니다: ..."),
+					@ExampleObject(name = "id_token 파싱 실패", value = "id_token 파싱에 실패했습니다 : ...")
+				}
+			)
+		)
+	})
+	ResponseEntity<?> socialCallback(
+		@Parameter(description = "소셜로그인에서 반환한 인증 코드") String code,
+		@Parameter(description = "디바이스 ID (선택 사항)") String deviceId,
+		@Parameter(description = "소셜로그인 제공자 (kakao, google, apple)") String socialProvider,
+		@Parameter(description = "플랫폼 (web, ios, android)") String platform
+	);
+
+	@Operation(
+		summary = "Social ID Token Login",
+		description = "ID 토큰을 이용한 로그인. Bearer 토큰을 Authorization 헤더에 포함해야 합니다.<br> X-Platform 헤더에 (web, ios, android)를 포함해야 합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "성공"),
+		@ApiResponse(
+			responseCode = "400",
+			description = "잘못된 요청",
+			content = @Content(
+				mediaType = "text/plain",
+				examples = {
+					@ExampleObject(name = "지원하지 않는 소셜 로그인 제공자", value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"),
+					@ExampleObject(name = "유효하지 않은 Authorization Header", value = "유효한 Authorization 헤더가 필요합니다. : authorizationHeader")
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "401",
+			description = "인증 정보가 잘못되었거나, 인증이 필요한 상황",
+			content = @Content(
+				mediaType = "text/plain",
+				examples = {
+					@ExampleObject(name = "id_token 비어있거나 null", value = "id_token이 비어있거나 null입니다. : idToken"),
+					@ExampleObject(name = "id_token 정보 중 sub가 존재하지 않을때", value = "id_token 정보중 회원번호(sub)가 없습니다.")
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "503",
+			description = "외부 API 요청 실패",
+			content = @Content(
+				mediaType = "text/plain",
+				examples = {
+					@ExampleObject(name = "토큰 발급 실패", value = "카카오 토큰 발급에 실패했습니다: ..."),
+					@ExampleObject(name = "id_token 파싱 실패", value = "id_token 파싱에 실패했습니다 : ...")
+				}
+			)
+		)
+	})
+	ResponseEntity<?> socialLoginWithIdToken(
+		@Parameter(description = "소셜에서 반환한 id_Token을 헤더에 담아주세요. Bearer 필요") String authorizationHeader,
+		@Parameter(description = "디바이스 ID (선택 사항)") String deviceId,
+		@Parameter(description = "소셜로그인 제공자 (kakao, google, apple)") String socialProvider,
+		@Parameter(description = "플랫폼 (web, ios, android)") String platform,
+		@Parameter(description = "소셜 로그인 Refresh_token, Bearer 필요") String refreshToken
+	);
+
+	@Operation(
+		summary = "Logout",
+		description = "특정 장치에서 로그아웃을 처리하고 해당 장치의 토큰을 삭제합니다.",
+		security = @SecurityRequirement(name = "bearer-key")
+	)
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "성공",
+			content = @Content(mediaType = "text/plain", examples = @ExampleObject(name = "로그아웃 성공", value = "로그아웃 성공"))
+		),
+		@ApiResponse(
+			responseCode = "401",
+			description = "인증 정보가 잘못되었거나, 인증이 필요한 상황",
+			content = @Content(mediaType = "text/plain", examples = @ExampleObject(name = "올바른 사용자 정보가 아닙니다.", value = "올바른 사용자 정보가 아닙니다."))
+		)
+	})
+	ResponseEntity<?> logout(
+		@Parameter(description = "로그아웃 할 member의 device_id를 입력해주세요.") String deviceId
+	);
+
+	@Operation(
+		summary = "Unlink",
+		description = "특정 회원의 연동을 해제합니다.",
+		security = @SecurityRequirement(name = "bearer-key")
+	)
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "성공",
+			content = @Content(mediaType = "text/plain", examples = @ExampleObject(name = "연결끊기 성공", value = "연결끊기 성공"))
+		),
+		@ApiResponse(
+			responseCode = "400",
+			description = "잘못된 요청",
+			content = @Content(
+				mediaType = "text/plain",
+				examples = {
+					@ExampleObject(name = "지원하지 않는 소셜 로그인 제공자", value = "지원하지 않는 소셜 로그인 제공자입니다 : gogle"),
+					@ExampleObject(name = "카카오 회원번호가 비어 있습니다.", value = "카카오 회원번호가 비어 있습니다.")
+				}
+			)
+		),
+		@ApiResponse(
+			responseCode = "401",
+			description = "인증 정보가 잘못되었거나, 인증이 필요한 상황",
+			content = @Content(mediaType = "text/plain", examples = @ExampleObject(name = "올바른 사용자 정보가 아닙니다.", value = "올바른 사용자 정보가 아닙니다."))
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = "리소스가 존재하지 않을때",
+			content = @Content(mediaType = "text/plain", examples = @ExampleObject(name = "회원을 찾을 수 없습니다.", value = "회원을 찾을 수 없습니다. ID: memberId"))
+		),
+		@ApiResponse(
+			responseCode = "503",
+			description = "외부 API 요청 실패",
+			content = @Content(mediaType = "text/plain", examples = @ExampleObject(name = "카카오 연결 끊기 실패", value = "카카오 연결 끊기에 실패했습니다: e.getMessage()"))
+		),
+		@ApiResponse(
+			responseCode = "500",
+			description = "서버 내부 오류",
+			content = @Content(mediaType = "text/plain", examples = @ExampleObject(name = "회원 삭제 중 오류가 발생했습니다.", value = "회원 삭제 중 오류가 발생했습니다."))
+		)
+	})
+	ResponseEntity<?> unlinkSocialAccount(
+		@Parameter(description = "소셜로그인 제공자 (kakao, google, apple)") String socialProvider
+	);
+}

--- a/src/main/java/com/traveljournal/domain/auth/service/AppleService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/AppleService.java
@@ -40,6 +40,9 @@ import com.traveljournal.domain.member.entity.SocialToken;
 import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.member.service.SocialTokenService;
 import com.traveljournal.domain.member.service.TokenService;
+import com.traveljournal.global.exception.BadRequestException;
+import com.traveljournal.global.exception.ExternalApiException;
+import com.traveljournal.global.exception.UnauthorizedException;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -129,13 +132,23 @@ public class AppleService {
 			clientId = servicesId; // 웹용 Service ID
 		}
 		String clientSecret = createClientSecret(clientId);
-		return appleClient.appleAuth(
-			clientId,
-			code,
-			"authorization_code",
-			clientSecret,
-			redirectUri
-		);
+		try {
+			return appleClient.appleAuth(
+				clientId,
+				code,
+				"authorization_code",
+				clientSecret,
+				redirectUri
+			);
+		} catch (feign.FeignException.BadRequest e) {
+			throw new BadRequestException("애플 인증 코드가 잘못되었습니다:" + e.contentUTF8());
+		} catch (feign.FeignException.Unauthorized e) {
+			throw new UnauthorizedException("애플 인증이 실패했습니다: " + e.contentUTF8());
+		} catch (feign.FeignException e) {
+			throw new ExternalApiException("애플 서버 통신 오류: " + e.contentUTF8());
+		} catch (Exception e) {
+			throw new ExternalApiException("애플 토큰 요청 중 알 수 없는 오류: " + e.getMessage());
+		}
 	}
 
 	// JWT 클라이언트 시크릿 생성
@@ -290,11 +303,9 @@ public class AppleService {
 		String clientId;
 		if (platform == Platform.IOS) {
 			clientId = iosBundleId;
-		}
-		else if (platform == Platform.ANDROID) {
+		} else if (platform == Platform.ANDROID) {
 			clientId = androidBundleId;
-		}
-		else {
+		} else {
 			clientId = servicesId;
 		}
 
@@ -302,16 +313,16 @@ public class AppleService {
 			// 클라이언트 시크릿 생성
 			String clientSecret = createClientSecret(clientId);
 
-				// 애플 서버에 연결 해제 요청
-				appleClient.revokeToken(
-					clientId,
-					clientSecret,
-					refreshToken,
-					"refresh_token"
-				);
+			// 애플 서버에 연결 해제 요청
+			appleClient.revokeToken(
+				clientId,
+				clientSecret,
+				refreshToken,
+				"refresh_token"
+			);
 
-				// 회원 계정에서 애플 연결 정보 삭제
-				memberService.deleteMember(memberId);
+			// 회원 계정에서 애플 연결 정보 삭제
+			memberService.deleteMember(memberId);
 		} catch (Exception e) {
 			throw new RuntimeException("애플 계정 연결 해제 실패: " + e.getMessage(), e);
 		}

--- a/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/AuthService.java
@@ -5,8 +5,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.traveljournal.domain.auth.dto.LoginCombinedResponse;
 import com.traveljournal.domain.member.entity.SocialProvider;
-import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.member.service.TokenService;
+import com.traveljournal.global.exception.BadRequestException;
 import com.traveljournal.global.security.jwt.JwtTokenProvider;
 
 import lombok.RequiredArgsConstructor;
@@ -22,16 +22,17 @@ public class AuthService {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final AppleService appleService;
 	private final GoogleService googleService;
-	private final MemberService memberService;
 
 	@Transactional
 	public LoginCombinedResponse handleLoginWithCode(SocialProvider socialProvider, String code, String deviceId,
 		String platform) {
+
+		validateCode(code);
+
 		return switch (socialProvider) {
 			case KAKAO -> kakaoService.processKakaoLoginWithCode(code, deviceId, socialProvider);
 			case APPLE -> appleService.processAppleLoginWithCode(code, deviceId, socialProvider, platform);
 			case GOOGLE -> googleService.processGoogleLoginWithCode(code, deviceId, socialProvider, platform);
-			default -> throw new UnsupportedOperationException("지원되지 않는 소셜 로그인 제공자입니다.");
 		};
 	}
 
@@ -49,7 +50,6 @@ public class AuthService {
 			case KAKAO -> kakaoService.processKakaoLoginWithIdToken(idToken, deviceId, socialProvider);
 			case APPLE -> appleService.processAppleLoginWithIdToken(idToken, deviceId, socialProvider, platform, refreshToken);
 			case GOOGLE -> googleService.processGoogleLoginWithIdToken(idToken, deviceId, socialProvider, platform, refreshToken);
-			default -> throw new UnsupportedOperationException("지원되지 않는 소셜 로그인 제공자입니다.");
 		};
 	}
 
@@ -66,8 +66,6 @@ public class AuthService {
 			case GOOGLE:
 				googleService.unlinkGoogleAccount(memberId);
 				break;
-			default:
-				throw new UnsupportedOperationException("지원되지 않는 소셜 로그인 제공자입니다.");
 		}
 	}
 
@@ -80,4 +78,9 @@ public class AuthService {
 		tokenService.deleteToken(memberId, deviceId);
 	}
 
+	private void validateCode(String code) {
+		if(code == null || code.isEmpty()) {
+			throw new BadRequestException("인증 코드 : " + code);
+		}
+	}
 }

--- a/src/main/java/com/traveljournal/domain/auth/service/GoogleService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/GoogleService.java
@@ -37,11 +37,11 @@ public class GoogleService {
 		// 구글 토큰 획득
 		GoogleTokenResponse googleTokenResponse = googleClient.getGoogleToken(code);
 
-		return processGoogleLoginWithIdToken(googleTokenResponse.id_token(), deviceId, socialProvider, googleTokenResponse.refresh_token(), platform);
+		return processGoogleLoginWithIdToken(googleTokenResponse.id_token(), deviceId, socialProvider, platform, googleTokenResponse.refresh_token());
 	}
 
 	public LoginCombinedResponse processGoogleLoginWithIdToken(String idToken, String deviceId,
-		SocialProvider socialProvider, String refreshToken, String platform) {
+		SocialProvider socialProvider, String platform, String refreshToken) {
 		// ID Token 으로 구글 사용자 정보 가져오기
 		GoogleIdTokenInfo googleIdTokenInfo = googleClient.getGoogleMemberInfoFromIdToken(idToken);
 

--- a/src/main/java/com/traveljournal/domain/auth/service/GoogleService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/GoogleService.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
 import com.traveljournal.domain.auth.dto.LoginCombinedResponse;
 import com.traveljournal.domain.auth.dto.LoginResponse;
@@ -18,6 +17,7 @@ import com.traveljournal.domain.member.entity.SocialProvider;
 import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.member.service.SocialTokenService;
 import com.traveljournal.domain.member.service.TokenService;
+import com.traveljournal.global.exception.BadRequestException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,12 +29,12 @@ public class GoogleService {
 	private final MemberService memberService;
 	private final GoogleClient googleClient;
 	private final SocialTokenService socialTokenService;
-	private final RestTemplate restTemplate;
-
 
 	public LoginCombinedResponse processGoogleLoginWithCode(String code, String deviceId,
 		SocialProvider socialProvider, String platform) {
-		// 구글 토큰 획득
+		if (code == null || code.isBlank()) {
+			throw new BadRequestException("구글 인증 코드가 비어 있습니다.");
+		}
 		GoogleTokenResponse googleTokenResponse = googleClient.getGoogleToken(code);
 
 		return processGoogleLoginWithIdToken(googleTokenResponse.id_token(), deviceId, socialProvider, platform, googleTokenResponse.refresh_token());
@@ -42,13 +42,10 @@ public class GoogleService {
 
 	public LoginCombinedResponse processGoogleLoginWithIdToken(String idToken, String deviceId,
 		SocialProvider socialProvider, String platform, String refreshToken) {
-		// ID Token 으로 구글 사용자 정보 가져오기
 		GoogleIdTokenInfo googleIdTokenInfo = googleClient.getGoogleMemberInfoFromIdToken(idToken);
 
-		// 회원 찾기 또는 생성
 		Member member = getMemberFromGoogleIdToken(googleIdTokenInfo, socialProvider);
 
-		// JWT 토큰 생성 및 저장
 		TokenInfo tokenInfo = createAndSaveTokens(member, deviceId);
 
 		if (refreshToken != null && !refreshToken.isEmpty()) {
@@ -61,7 +58,6 @@ public class GoogleService {
 				platform);
 		}
 
-		// 로그인 응답 생성
 		return createLoginResponse(member, tokenInfo);
 	}
 
@@ -77,12 +73,8 @@ public class GoogleService {
 	}
 
 	private TokenInfo createAndSaveTokens(Member member, String deviceId) {
-		// JWT 토큰 생성
 		TokenInfo tokenInfo = tokenService.createTokens(member.getProviderId(), deviceId);
-
-		// 토큰 저장
 		tokenService.saveOrUpdateToken(member, tokenInfo.deviceId(), tokenInfo.refreshToken());
-
 		return tokenInfo;
 	}
 
@@ -90,33 +82,23 @@ public class GoogleService {
 		return LoginCombinedResponse.of(LoginResponse.from(member, tokenInfo), tokenInfo.accessToken());
 	}
 
-
 	public void unlinkGoogleAccount(Long memberId) {
-		// 회원 정보 조회
 		Member member = memberService.findById(memberId);
-		// 회원의 구글 식별자(sub) 가져오기
 		String googleUserId = member.getProviderId();
 
 		if (googleUserId == null || googleUserId.isEmpty()) {
-			throw new RuntimeException("구글 계정 연결 정보가 없습니다.");
+			throw new BadRequestException("구글 계정 연결 정보가 없습니다.");
 		}
 
-		try {
-			// 리프레시 토큰 조회 및 처리
-			Optional<String> refreshTokenOpt = socialTokenService.getSocialRefreshToken(memberId, SocialProvider.GOOGLE);
+		Optional<String> refreshTokenOpt = socialTokenService.getSocialRefreshToken(memberId, SocialProvider.GOOGLE);
 
-			if (refreshTokenOpt.isPresent()) {
-				String refreshToken = refreshTokenOpt.get();
-
-				googleClient.revokeToken(refreshToken);
-
-				memberService.deleteMember(memberId);
-			} else {
-					throw new RuntimeException("구글 계정 연결 해제 실패");
-				}
-
-		} catch (Exception e) {
-			throw new RuntimeException("구글 계정 연결 해제 실패: " + e.getMessage(), e);
+		if (refreshTokenOpt.isEmpty()) {
+			throw new BadRequestException("구글 계정 연결 해제 실패: 리프레시 토큰이 없습니다.");
 		}
+
+		String refreshToken = refreshTokenOpt.get();
+		googleClient.revokeToken(refreshToken);
+
+		memberService.deleteMember(memberId);
 	}
 }

--- a/src/main/java/com/traveljournal/domain/auth/service/KakaoService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/KakaoService.java
@@ -63,7 +63,6 @@ public class KakaoService {
 	 */
 	public void unlinkKakaoAccount(Long memberId) {
 		try {
-			log.info("카카오 계정 연결 끊기 시작: memberId={}", memberId);
 
 			// 회원 정보 조회
 			Member member = memberService.findById(memberId);
@@ -74,9 +73,7 @@ public class KakaoService {
 			// 회원 정보 삭제
 			memberService.deleteMember(memberId);
 
-			log.info("카카오 계정 연결 끊기 완료: memberId={}", memberId);
 		} catch (Exception e) {
-			log.error("카카오 계정 연결 끊기 실패: {}", e.getMessage());
 			throw new ExternalApiException("카카오 계정 연결 끊기에 실패했습니다: " + e.getMessage());
 		}
 	}

--- a/src/main/java/com/traveljournal/domain/auth/service/KakaoService.java
+++ b/src/main/java/com/traveljournal/domain/auth/service/KakaoService.java
@@ -13,7 +13,6 @@ import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.member.entity.SocialProvider;
 import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.member.service.TokenService;
-import com.traveljournal.global.exception.ExternalApiException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +25,7 @@ public class KakaoService {
 	private final TokenService tokenService;
 	private final KakaoClient kakaoClient;
 	private final MemberService memberService;
+
 	/**
 	 * 카카오 로그인 처리
 	 * 1. 카카오 인증 코드로 액세스 토큰 요청
@@ -34,7 +34,8 @@ public class KakaoService {
 	 * 4. JWT 토큰 생성 및 저장
 	 * 5. 로그인 응답 생성
 	 */
-	public LoginCombinedResponse processKakaoLoginWithCode(String code, String deviceId, SocialProvider socialProvider) {
+	public LoginCombinedResponse processKakaoLoginWithCode(String code, String deviceId,
+		SocialProvider socialProvider) {
 
 		// 카카오 토큰 획득
 		KakaoTokenResponse kakaoTokenResponse = kakaoClient.getKakaoToken(code);
@@ -42,7 +43,8 @@ public class KakaoService {
 		return processKakaoLoginWithIdToken(kakaoTokenResponse.id_token(), deviceId, socialProvider);
 	}
 
-	public LoginCombinedResponse processKakaoLoginWithIdToken(String idToken, String deviceId, SocialProvider socialProvider) {
+	public LoginCombinedResponse processKakaoLoginWithIdToken(String idToken, String deviceId,
+		SocialProvider socialProvider) {
 
 		// ID Token으로 카카오 사용자 정보 가져오기
 		KakaoIdTokenInfo kakaoIdTokenInfo = kakaoClient.getKakaoMemberInfoFromIdToken(idToken);
@@ -62,22 +64,16 @@ public class KakaoService {
 	 * 2. 회원 정보 삭제
 	 */
 	public void unlinkKakaoAccount(Long memberId) {
-		try {
 
-			// 회원 정보 조회
-			Member member = memberService.findById(memberId);
+		// 회원 정보 조회
+		Member member = memberService.findById(memberId);
 
-			// 카카오 API를 통해 연결 끊기
-			kakaoClient.unlinkKakaoUser(member.getProviderId());
+		// 카카오 API를 통해 연결 끊기
+		kakaoClient.unlinkKakaoUser(member.getProviderId());
 
-			// 회원 정보 삭제
-			memberService.deleteMember(memberId);
-
-		} catch (Exception e) {
-			throw new ExternalApiException("카카오 계정 연결 끊기에 실패했습니다: " + e.getMessage());
-		}
+		// 회원 정보 삭제
+		memberService.deleteMember(memberId);
 	}
-
 
 	private Member getMemberFromIdToken(KakaoIdTokenInfo kakaoIdTokenInfo, SocialProvider socialProvider) {
 		return memberService.findOrCreateMember(

--- a/src/main/java/com/traveljournal/domain/auth/util/EnumUtils.java
+++ b/src/main/java/com/traveljournal/domain/auth/util/EnumUtils.java
@@ -8,7 +8,7 @@ public class EnumUtils {
 		try {
 			return SocialProvider.valueOf(socialProviderStr.trim().toUpperCase());
 		} catch (IllegalArgumentException e) {
-			throw new BadRequestException("지원하지 않는 소숄 로그인 제공자입니다 : " + socialProviderStr);
+			throw new BadRequestException("지원하지 않는 소셜 로그인 제공자입니다 : " + socialProviderStr);
 		}
 	}
 }

--- a/src/main/java/com/traveljournal/domain/auth/util/EnumUtils.java
+++ b/src/main/java/com/traveljournal/domain/auth/util/EnumUtils.java
@@ -1,13 +1,14 @@
 package com.traveljournal.domain.auth.util;
 
 import com.traveljournal.domain.member.entity.SocialProvider;
+import com.traveljournal.global.exception.BadRequestException;
 
 public class EnumUtils {
 	public static SocialProvider toSocialProvider(String socialProviderStr) {
 		try {
 			return SocialProvider.valueOf(socialProviderStr.trim().toUpperCase());
 		} catch (IllegalArgumentException e) {
-			throw new IllegalArgumentException("Invalid SocialProvider: " + socialProviderStr, e);
+			throw new BadRequestException("지원하지 않는 소숄 로그인 제공자입니다 : " + socialProviderStr);
 		}
 	}
 }

--- a/src/main/java/com/traveljournal/domain/auth/util/GoogleClient.java
+++ b/src/main/java/com/traveljournal/domain/auth/util/GoogleClient.java
@@ -3,7 +3,9 @@ package com.traveljournal.domain.auth.util;
 import java.net.URL;
 import java.text.ParseException;
 
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -18,7 +20,9 @@ import com.traveljournal.domain.auth.dto.google.GoogleIdTokenInfo;
 import com.traveljournal.domain.auth.dto.google.GoogleMemberInfo;
 import com.traveljournal.domain.auth.dto.google.GoogleTokenResponse;
 import com.traveljournal.global.config.GoogleOAuthConfig;
+import com.traveljournal.global.exception.BadRequestException;
 import com.traveljournal.global.exception.ExternalApiException;
+import com.traveljournal.global.exception.UnauthorizedException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,9 +34,8 @@ public class GoogleClient {
     private final GoogleOAuthConfig googleOAuthConfig;
     private final RestTemplate restTemplate;
     private static final String GOOGLE_JWK_URL = "https://www.googleapis.com/oauth2/v3/certs";
-    /**
-     * 구글 인증 코드로 토큰 정보 요청
-     */
+
+    // 구글 인증 코드로 토큰 정보 요청
     public GoogleTokenResponse getGoogleToken(String code) {
         try {
             HttpHeaders headers = new HttpHeaders();
@@ -44,106 +47,79 @@ public class GoogleClient {
             params.add("client_secret", googleOAuthConfig.getClientSecret());
             params.add("redirect_uri", googleOAuthConfig.getRedirectUri());
             params.add("grant_type", "authorization_code");
-            params.add("access_type", "offline");  // 리프레시 토큰을 받기 위한 설정
+            params.add("access_type", "offline");
             params.add("prompt", "consent");
-            log.info("🚀 Google OAuth 요청 - clientId: {}, clientSecret: {}, redirectUri: {}",
-                    googleOAuthConfig.getClientId(),
-                    googleOAuthConfig.getClientSecret(),
-                    googleOAuthConfig.getRedirectUri());
-            log.info("🚀 [Google OAuth] 토큰 요청 URL: {}", googleOAuthConfig.getTokenUri());
-            log.info("🚀 [Google OAuth] 요청 파라미터: {}", params);
 
             HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
 
             GoogleTokenResponse response = restTemplate.postForObject(
-                    googleOAuthConfig.getTokenUri(),
-                    request,
-                    GoogleTokenResponse.class
+                googleOAuthConfig.getTokenUri(),
+                request,
+                GoogleTokenResponse.class
             );
-
-            log.info("✅ [Google OAuth] 토큰 발급 성공: {}", response);
 
             if (response == null) {
                 throw new ExternalApiException("구글 토큰 응답이 null 입니다.");
             }
-            log.info("구글 OAuth 응답 - ID 토큰: {}", response);
-            log.info("구글 토큰 발급 성공");
             return response;
+        } catch (org.springframework.web.client.HttpClientErrorException.BadRequest e) {
+            log.error("구글 토큰 발급 실패(400): {}", e.getMessage());
+            throw new BadRequestException("구글 인증 코드가 잘못되었습니다: " + e.getMessage());
+        } catch (org.springframework.web.client.HttpClientErrorException.Unauthorized e) {
+            log.error("구글 토큰 발급 실패(401): {}", e.getMessage());
+            throw new UnauthorizedException("구글 인증이 실패했습니다: " + e.getMessage());
+        } catch (org.springframework.web.client.HttpClientErrorException e) {
+            log.error("구글 토큰 발급 실패(4xx/5xx): {}", e.getMessage());
+            throw new ExternalApiException("구글 토큰 발급에 실패했습니다: " + e.getMessage());
         } catch (Exception e) {
-            log.error("구글 토큰 발급 실패 : {}", e.getMessage());
-            throw new ExternalApiException("구글 토큰 발급에 실패했습니다." + e.getMessage());
+            log.error("구글 토큰 발급 실패(기타): {}", e.getMessage());
+            throw new ExternalApiException("구글 토큰 발급에 실패했습니다: " + e.getMessage());
         }
     }
 
-    /**
-     * 구글 액세스 토큰으로 사용자 정보 가져오기
-     */
-
     public GoogleMemberInfo getGoogleMemberInfo(String accessToken) {
         String memberInfoUrl = "https://www.googleapis.com/oauth2/v2/userinfo?access_token=" + accessToken;
-
-        log.info("구글 사용자 정보 요청: {}", memberInfoUrl);
-
-        return restTemplate.getForObject(memberInfoUrl, GoogleMemberInfo.class);
-
+        try {
+            return restTemplate.getForObject(memberInfoUrl, GoogleMemberInfo.class);
+        } catch (org.springframework.web.client.HttpClientErrorException.Unauthorized e) {
+            throw new UnauthorizedException("구글 인증이 실패했습니다: " + e.getMessage());
+        } catch (org.springframework.web.client.HttpClientErrorException e) {
+            throw new ExternalApiException("구글 사용자 정보 조회 실패: " + e.getMessage());
+        } catch (Exception e) {
+            throw new ExternalApiException("구글 사용자 정보 조회 중 오류: " + e.getMessage());
+        }
     }
 
-    /**
-     * ID Token 서명 검증
-     */
-    public static void verifyIdToken(String idToken) throws Exception{
+    public static void verifyIdToken(String idToken) {
         try {
-
-            // 공개 키 가져오기
             URL jwkUrl = new URL(GOOGLE_JWK_URL);
             JWKSet jwkSet = JWKSet.load(jwkUrl);
 
-            // ID Token 파싱
             SignedJWT signedJWT = SignedJWT.parse(idToken);
             JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
-
-            // JWT 헤더에서 키 ID 추출
-            // 공개 키 찾기 위한 kid 값 추출
             String kid = signedJWT.getHeader().getKeyID();
+            JWK jwk = jwkSet.getKeyByKeyId(kid);
 
-            // 공개 키 찾기
-            JWK jwk = jwkSet.getKeyByKeyId(kid);  // 공개 키 찾기
-
-            // 공개 키 셋과 kid 값 확인
-            log.info("JWK Set: {}", jwkSet);
-            log.info("kid: {}", kid);
-
-            // 공개 키 확인
-            log.info("JWK: {}", jwk);
             if (jwk == null) {
                 throw new ExternalApiException("유효한 공개 키를 찾을 수 없습니다.");
             }
 
-            // 공개 키로 RSASSAVerifier 생성
             RSASSAVerifier verifier = new RSASSAVerifier(jwk.toRSAKey());
-
-            // 서명 검증
             if (!signedJWT.verify(verifier)) {
-                throw new ExternalApiException("ID 토큰 서명 검증에 실패했습니다.");
+                throw new UnauthorizedException("ID 토큰 서명 검증에 실패했습니다.");
             }
-
-            log.info("구글 ID 토큰 서명 검증 성공");
-
         } catch (ParseException | java.io.IOException e) {
-            log.error("ID 토큰 파싱 또는 공개 키 로딩 실패 : {}", e.getMessage());
-            throw new ExternalApiException("ID 토큰 검증에 실패했습니다." + e.getMessage());
+            throw new BadRequestException("ID 토큰 파싱 또는 공개 키 로딩 실패: " + e.getMessage());
+        } catch (Exception e) {
+            throw new ExternalApiException("ID 토큰 검증에 실패했습니다: " + e.getMessage());
         }
     }
+
     public GoogleIdTokenInfo getGoogleMemberInfoFromIdToken(String idToken) {
         try {
-
-            log.info("받은 ID 토큰: {}", idToken);
-            // ID Token 서명 검증
             verifyIdToken(idToken);
 
-            // ID Token 디코딩
             SignedJWT signedJWT = SignedJWT.parse(idToken);
-            log.info("Signed JWT decoded successfully: {}", signedJWT);
             JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
 
             String sub = claims.getSubject();
@@ -151,23 +127,24 @@ public class GoogleClient {
             String nickname = claims.getStringClaim("name");
             String picture = claims.getStringClaim("picture");
 
-            log.info("구글 ID Token 정보 : sub={}, email={}, nickname={}, picture={}", sub, email, nickname, picture);
             return new GoogleIdTokenInfo(sub, email, nickname, picture);
-
+        } catch (BadRequestException | UnauthorizedException | ExternalApiException e) {
+            throw e;
         } catch (Exception e) {
-            log.error("ID Token 파싱 실패 : {}", e.getMessage());
-            throw new ExternalApiException("ID Token 파싱에 실패했습니다." + e.getMessage());
+            throw new ExternalApiException("ID Token 파싱에 실패했습니다: " + e.getMessage());
         }
     }
 
     public void revokeToken(String refreshToken) {
         String revokeUrl = "https://oauth2.googleapis.com/revoke?token=" + refreshToken;
-
         try {
             restTemplate.postForObject(revokeUrl, null, String.class);
+        } catch (org.springframework.web.client.HttpClientErrorException.BadRequest e) {
+            throw new BadRequestException("구글 토큰 해제 요청이 잘못되었습니다: " + e.getMessage());
+        } catch (org.springframework.web.client.HttpClientErrorException.Unauthorized e) {
+            throw new UnauthorizedException("구글 인증이 실패했습니다: " + e.getMessage());
         } catch (Exception e) {
-            throw new RuntimeException("구글 계정 연결 해제 실패",e);
+            throw new ExternalApiException("구글 계정 연결 해제 실패: " + e.getMessage());
         }
     }
 }
-

--- a/src/main/java/com/traveljournal/domain/auth/util/KakaoClient.java
+++ b/src/main/java/com/traveljournal/domain/auth/util/KakaoClient.java
@@ -14,7 +14,9 @@ import com.nimbusds.jwt.SignedJWT;
 import com.traveljournal.domain.auth.dto.kakao.KakaoIdTokenInfo;
 import com.traveljournal.domain.auth.dto.kakao.KakaoTokenResponse;
 import com.traveljournal.global.config.KakaoOAuthConfig;
+import com.traveljournal.global.exception.BadRequestException;
 import com.traveljournal.global.exception.ExternalApiException;
+import com.traveljournal.global.exception.UnauthorizedException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,37 +55,47 @@ public class KakaoClient {
 			if (response == null) {
 				throw new ExternalApiException("카카오 토큰 응답이 null입니다.");
 			}
-
-			log.info("카카오 토큰 발급 성공");
 			return response;
-
+		} catch (BadRequestException | ExternalApiException e) {
+			throw e;
 		} catch (Exception e) {
-			log.error("카카오 토큰 발급 실패: {}", e.getMessage());
 			throw new ExternalApiException("카카오 토큰 발급에 실패했습니다: " + e.getMessage());
 		}
 	}
 
 	public KakaoIdTokenInfo getKakaoMemberInfoFromIdToken(String idToken) {
 		try {
+			if (idToken == null || idToken.isBlank()) {
+				throw new UnauthorizedException("id_token이 비어있거나 null입니다. : " + idToken);
+			}
+
 			// ID Token 디코딩
 			SignedJWT signedJWT = SignedJWT.parse(idToken);
 			JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
 
 			String sub = claims.getSubject(); // 카카오 회원번호
-			String email = (String) claims.getClaim("email");
-			String nickname = (String) claims.getClaim("nickname");
-			String picture = (String) claims.getClaim("picture"); // 프로필 이미지
+			if (sub == null || sub.isBlank()) {
+				throw new UnauthorizedException("id_token 정보 중 회원번호(sub)가 없습니다.");
+			}
 
-			log.info("카카오 ID Token 정보: sub={}, email={}, nickname={}, picture={}", sub, email, nickname, picture);
+			String email = (String)claims.getClaim("email");
+			String nickname = (String)claims.getClaim("nickname");
+			String picture = (String)claims.getClaim("picture"); // 프로필 이미지
+
 			return new KakaoIdTokenInfo(sub, email, nickname, picture);
+		} catch (UnauthorizedException | ExternalApiException e) {
+			throw e;
 		} catch (Exception e) {
-			log.error("ID Token 파싱 실패: {}", e.getMessage());
-			throw new ExternalApiException("ID Token 파싱에 실패했습니다: " + e.getMessage());
+			throw new ExternalApiException("id_token 파싱에 실패했습니다: " + e.getMessage());
 		}
 	}
 
 	public void unlinkKakaoUser(String kakaoUserId) {
 		try {
+			if (kakaoUserId == null || kakaoUserId.isBlank()) {
+				throw new BadRequestException("카카오 회원번호가 비어 있습니다.");
+			}
+
 			HttpHeaders headers = new HttpHeaders();
 			headers.set("Authorization", "KakaoAK " + kakaoOAuthConfig.getAdminKey());
 
@@ -99,10 +111,9 @@ public class KakaoClient {
 				entity,
 				Void.class
 			);
-
-			log.info("카카오 연결 끊기 성공: kakaoUserId={}", kakaoUserId);
+		} catch (BadRequestException | ExternalApiException e) {
+			throw e;
 		} catch (Exception e) {
-			log.error("카카오 연결 끊기 실패: {}", e.getMessage());
 			throw new ExternalApiException("카카오 연결 끊기에 실패했습니다: " + e.getMessage());
 		}
 	}

--- a/src/main/java/com/traveljournal/domain/member/service/MemberService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/MemberService.java
@@ -17,6 +17,7 @@ import com.traveljournal.domain.member.entity.SocialProvider;
 import com.traveljournal.domain.member.repository.MemberRepository;
 import com.traveljournal.domain.member.repository.SocialTokenRepository;
 import com.traveljournal.domain.member.repository.TokenRepository;
+import com.traveljournal.global.exception.MemberDeleteException;
 import com.traveljournal.global.exception.ResourceNotFoundException;
 
 import io.jsonwebtoken.io.IOException;
@@ -173,10 +174,8 @@ public class MemberService {
 			memberRepository.flush();
 			entityManager.clear();
 
-			log.info("회원 삭제 완료. ID: {}", memberId);
 		} catch (Exception e) {
-			log.error("회원 삭제 중 오류 발생. ID: {}", memberId, e);
-			throw new RuntimeException("회원 삭제 중 오류가 발생했습니다.", e);
+			throw new MemberDeleteException("회원 삭제 중 오류가 발생했습니다.", e);
 		}
 	}
 }

--- a/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
+++ b/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
@@ -1,20 +1,24 @@
 package com.traveljournal.domain.search.controller;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.traveljournal.domain.search.dto.MemberSearchResponse;
 import com.traveljournal.domain.search.service.MemberSearchService;
 import com.traveljournal.global.data.ApiResponseHandler;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,7 +34,7 @@ public class SearchController {
             summary = "사용자 검색",
             description = "사용자가 입력한 키워드로 다른 사용자를 검색합니다.",
             security = @SecurityRequirement(name = "bearer-key"))
-    public ResponseEntity<?> searchMembers(
+    public ResponseEntity<Page<MemberSearchResponse>> searchMembers(
             @RequestParam @NotBlank(message = "검색어는 비어 있을 수 없습니다.") String keyword,
             @PageableDefault(sort = "nickname") Pageable pageable)
     {

--- a/src/main/java/com/traveljournal/global/data/JwtValidateStatus.java
+++ b/src/main/java/com/traveljournal/global/data/JwtValidateStatus.java
@@ -1,7 +1,10 @@
 package com.traveljournal.global.data;
 
 public enum JwtValidateStatus {
-	ACCEPTED,
-	EXPIRED,
-	DENIED
+	ACCEPTED,          // 정상
+	EXPIRED,           // 만료됨
+	INVALID,           // 변조/서명 오류 등 유효하지 않음
+	EMPTY,             // 토큰 없음
+	UNSUPPORTED,       // 지원하지 않는 토큰 형식
+	ERROR              // 기타 예외 (파싱 실패 등)
 }

--- a/src/main/java/com/traveljournal/global/exception/BadRequestException.java
+++ b/src/main/java/com/traveljournal/global/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.traveljournal.global.exception;
+
+public class BadRequestException extends RuntimeException {
+	public BadRequestException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/traveljournal/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/traveljournal/global/exception/GlobalExceptionHandler.java
@@ -22,4 +22,9 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<String> handleBadRequest(BadRequestException ex) {
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
 	}
+
+	@ExceptionHandler(ExternalApiException.class)
+	public ResponseEntity<String> handleExternalApi(ExternalApiException ex) {
+		return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(ex.getMessage());
+	}
 }

--- a/src/main/java/com/traveljournal/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/traveljournal/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.traveljournal.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(UnauthorizedException.class)
+	public ResponseEntity<String> handleUnauthorized(UnauthorizedException ex) {
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
+	}
+
+	@ExceptionHandler(ResourceNotFoundException.class)
+	public ResponseEntity<String> handleNotFound(ResourceNotFoundException ex) {
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+	}
+
+	@ExceptionHandler(BadRequestException.class)
+	public ResponseEntity<String> handleBadRequest(BadRequestException ex) {
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+	}
+}

--- a/src/main/java/com/traveljournal/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/traveljournal/global/exception/GlobalExceptionHandler.java
@@ -27,4 +27,9 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<String> handleExternalApi(ExternalApiException ex) {
 		return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(ex.getMessage());
 	}
+
+	@ExceptionHandler(MemberDeleteException.class)
+	public ResponseEntity<String> handleMemberDelete(MemberDeleteException ex) {
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ex.getMessage());
+	}
 }

--- a/src/main/java/com/traveljournal/global/exception/MemberDeleteException.java
+++ b/src/main/java/com/traveljournal/global/exception/MemberDeleteException.java
@@ -1,0 +1,7 @@
+package com.traveljournal.global.exception;
+
+public class MemberDeleteException extends RuntimeException {
+	public MemberDeleteException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/main/java/com/traveljournal/global/exception/UserNotFoundException.java
+++ b/src/main/java/com/traveljournal/global/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.traveljournal.global.exception;
+
+public class UserNotFoundException extends RuntimeException {
+	public UserNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/traveljournal/global/security/auth/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/traveljournal/global/security/auth/CustomAuthenticationEntryPoint.java
@@ -23,26 +23,45 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 	public void commence(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException authException) throws IOException, ServletException {
 
-		// 응답이 이미 커밋되었으면 예외 처리 중단
 		if (response.isCommitted()) {
 			return;
 		}
 
-		// 상태 코드 설정
 		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-
-		// 캐싱 방지 헤더 추가
 		response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
 		response.setHeader("Pragma", "no-cache");
 		response.setDateHeader("Expires", 0);
-
-		// 메시지 반환
 		response.setContentType("application/json");
 		response.setCharacterEncoding("UTF-8");
 
-		// JSON 응답 생성
+		String exception = (String) request.getAttribute("exception");
+		String message;
+		String code;
+
+		if ("USER_NOT_FOUND".equals(exception)) {
+			code = "USER_NOT_FOUND";
+			message = "사용자를 찾을 수 없습니다 -> 토큰에 담겨 있는 sub에 맞는 회원번호가 없습니다.";
+		}
+		else if ("TOKEN_EXPIRED".equals(exception)) {
+			code = "TOKEN_EXPIRED";
+			message = "토큰이 만료되었습니다.";
+		} else if ("TOKEN_INVALID".equals(exception)) {
+			code = "TOKEN_INVALID";
+			message = "유효하지 않은 토큰입니다.";
+		} else if ("TOKEN_UNKNOWN".equals(exception)) {
+			code = "TOKEN_UNKNOWN";
+			message = "알 수 없는 토큰 오류입니다.";
+		} else if ("TOKEN_ERROR".equals(exception)) {
+			code = "TOKEN_ERROR";
+			message = "토큰 처리 중 오류가 발생했습니다.";
+		} else {
+			code = "UNAUTHORIZED";
+			message = "Unauthorized: 인증이 필요합니다.";
+		}
+
 		Map<String, String> errorResponse = new HashMap<>();
-		errorResponse.put("message", "Unauthorized: 인증이 필요합니다.");
+		errorResponse.put("code", code);
+		errorResponse.put("message", message);
 		errorResponse.put("status", "401");
 
 		String jsonResponse = objectMapper.writeValueAsString(errorResponse);

--- a/src/main/java/com/traveljournal/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/traveljournal/global/security/jwt/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.traveljournal.global.data.JwtValidateStatus;
+import com.traveljournal.global.exception.UserNotFoundException;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -37,24 +38,36 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 		// 토큰이 있는 경우에만 처리
 		if (authorization != null) {
-			// Bearer 토큰 추출
 			String token = jwtTokenProvider.resolveToken(authorization);
 
 			if (token != null) {
-				// 토큰 유효성 검사
-				JwtValidateStatus status = jwtTokenProvider.getTokenValidationStatus(token);
+				try {
+					JwtValidateStatus status = jwtTokenProvider.getTokenValidationStatus(token);
 
-				if (status == JwtValidateStatus.ACCEPTED) {
-					try {
-						// 인증 정보 설정
+					if (status == JwtValidateStatus.ACCEPTED) {
 						jwtTokenProvider.setAuthentication(token);
-						log.debug("토큰 인증 성공");
-					} catch (Exception e) {
-						log.error("토큰 처리 중 에러 발생: {}", e.getMessage());
+						log.error("토큰 인증 성공");
+					} else if (status == JwtValidateStatus.EXPIRED) {
+						request.setAttribute("exception", "TOKEN_EXPIRED");
+						log.error("토큰 만료");
+						SecurityContextHolder.clearContext();
+					} else if (status == JwtValidateStatus.INVALID) {
+						request.setAttribute("exception", "TOKEN_INVALID");
+						log.error("유효하지 않은 토큰");
+						SecurityContextHolder.clearContext();
+					} else {
+						request.setAttribute("exception", "TOKEN_UNKNOWN");
+						log.error("알 수 없는 토큰 오류");
 						SecurityContextHolder.clearContext();
 					}
-				} else {
-					log.debug("유효하지 않은 토큰: {}", status);
+				} catch (UserNotFoundException e) {
+					request.setAttribute("exception", "USER_NOT_FOUND");
+					log.debug("사용자를 찾을 수 없습니다: {}", e.getMessage());
+					SecurityContextHolder.clearContext();
+				} catch (Exception e) {
+					log.error("토큰 처리 중 에러 발생: {}", e.getMessage());
+					request.setAttribute("exception", "TOKEN_ERROR");
+					SecurityContextHolder.clearContext();
 				}
 			}
 		}

--- a/src/main/java/com/traveljournal/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/traveljournal/global/security/jwt/JwtTokenProvider.java
@@ -20,6 +20,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -106,6 +107,9 @@ public class JwtTokenProvider {
 	 *  DENIED 검증 실패
 	 */
 	public JwtValidateStatus getTokenValidationStatus(String token) {
+		if (token == null || token.isBlank()) {
+			return JwtValidateStatus.EMPTY;
+		}
 		try {
 			Jwts.parserBuilder()
 				.setSigningKey(secretKey)
@@ -114,8 +118,12 @@ public class JwtTokenProvider {
 			return JwtValidateStatus.ACCEPTED;
 		} catch (ExpiredJwtException e) {
 			return JwtValidateStatus.EXPIRED;
+		} catch (UnsupportedJwtException e) {
+			return JwtValidateStatus.UNSUPPORTED;
 		} catch (JwtException e) {
-			return JwtValidateStatus.DENIED;
+			return JwtValidateStatus.INVALID;
+		} catch (Exception e) {
+			return JwtValidateStatus.ERROR;
 		}
 	}
 

--- a/src/main/java/com/traveljournal/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/traveljournal/global/security/jwt/JwtTokenProvider.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 import com.traveljournal.global.config.AppConfig;
 import com.traveljournal.global.data.JwtValidateStatus;
+import com.traveljournal.global.exception.BadRequestException;
 import com.traveljournal.global.security.service.CustomUserDetailsService;
 
 import io.jsonwebtoken.Claims;
@@ -147,7 +148,7 @@ public class JwtTokenProvider {
 
 	private void validateAuthorizationHeader(String authorizationHeader) {
 		if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-			throw new IllegalArgumentException("유효한 Authorization 헤더가 필요합니다.");
+			throw new BadRequestException("유효한 Authorization 헤더가 필요합니다. : " + authorizationHeader);
 		}
 	}
 

--- a/src/main/java/com/traveljournal/global/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/traveljournal/global/security/service/CustomUserDetailsService.java
@@ -2,12 +2,12 @@ package com.traveljournal.global.security.service;
 
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.member.repository.MemberRepository;
+import com.traveljournal.global.exception.UserNotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,9 +22,9 @@ public class CustomUserDetailsService implements UserDetailsService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public UserDetails loadUserByUsername(String providerId) throws UsernameNotFoundException {
+	public UserDetails loadUserByUsername(String providerId) {
 		Member member = memberRepository.findByProviderId(providerId)
-			.orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + providerId));
+			.orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다: " + providerId));
 
 		// CustomUserDetails 반환
 		return new CustomUserDetails(member);

--- a/src/main/java/com/traveljournal/global/security/util/SecurityUtil.java
+++ b/src/main/java/com/traveljournal/global/security/util/SecurityUtil.java
@@ -3,6 +3,7 @@ package com.traveljournal.global.security.util;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import com.traveljournal.global.exception.UnauthorizedException;
 import com.traveljournal.global.security.service.CustomUserDetails;
 
 /**
@@ -19,7 +20,7 @@ public class SecurityUtil {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
 		if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {
-			throw new IllegalStateException("올바른 사용자 정보가 아닙니다.");
+			throw new UnauthorizedException("올바른 사용자 정보가 아닙니다.");
 		}
 		return userDetails.getMemberId();
 	}


### PR DESCRIPTION
## 🔥 해결된 이슈
- Closes #26 
- TJFE-161
## 📌 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련된 테스트를 추가하거나 기존 테스트를 실행하여 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드를 따랐는지 확인했습니다.
- [x] 배포가 필요한 경우 관련 작업을 완료했습니다. (예: CI/CD 설정, 환경 변수 추가 등)

## ✨ 작업 내용
- Auth 관련 정상적으로 예외처리가 작동하도록 변경하였습니다.
- Auth한정 Swagger 예외처리에 따라 문서화시켰습니다.
> Controller에 많은 정보가 담겨져있어서 문서의 경우 docs를 따로 인터페이스로 구현하였습니다.
- 프론트에서 토큰이 만료되었는지 안되었는지 무슨문제인지 알 수 없었던 점을 해결하여 구현하였습니다.
- 구글, 카카오, 애플 서비스 및 클라이언트의 예외처리를 진행하였습니다.
## 🚀 추가 설명
> 예외처리 작업 시 global - exception 패키지 경로에 있는 것들을 사용해주시면 됩니다.
BadRequestException : 400
> 잘못된 요청, 파라미터 오류, 유효성 검증 실패 등
UnauthorizedException : 401
> 인증이 필요하거나, 인증 정보가 잘못된 경우
ResourceNotFoundException : 404
> 리소스(회원, 게시물 등)가 존재하지 않는 경우
ExternalApiException : 503
> 외부 API 장애, 서버가 일시적으로 불능인 경우

필요하신것은 만들어서 사용하시면 됩니다.
## 📸 테스트 결과 (스크린샷 혹은 로그)
> : Social Login시 kakao, google, apple이 아닌 제공자가 들어왔을때 예외처리
![Pasted Graphic](https://github.com/user-attachments/assets/efbc9845-52e1-425b-9aaa-3c0d1f8ade7d)

> : 인증코드가 비었거나 null일 경우 예외처리
![Pasted Graphic 1](https://github.com/user-attachments/assets/f4c24d62-6ccf-448d-a028-28a97fe54088)

> : Social Login Callback Responses
![Pasted Graphic 3](https://github.com/user-attachments/assets/519286bc-2183-4f8b-b002-8ac2e152c406)

> : 회원탈퇴 - 탈퇴중 서버내부에서 오류가 있을때 HTTP 상태코드 500
![Pasted Graphic 4](https://github.com/user-attachments/assets/ded9d271-b9c0-466d-acc4-7e3b3ca01ce8)

> 토큰 관련 
: 1. 액세스 토큰 안의 sub(회원번호)가 DB의 회원번호가 일치하지 않을때
![Pasted Graphic 5](https://github.com/user-attachments/assets/7e80dc3f-e646-4e94-976c-75cd05c3c29b)
2. 유효하지 않은 액세스 토큰일때
![Pasted Graphic 6](https://github.com/user-attachments/assets/b7f17a8f-0390-44e9-bf2d-b4bca4cfc751)
3. 액세스 토큰이 만료되었을때 
![Pasted Graphic 7](https://github.com/user-attachments/assets/96b68365-3f20-4619-9753-ae3269c4000c)



