### PR TITLE
[Feature] 조회 기능 구현 - 검색(여행일지, 플레이스)

### DIFF
--- a/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/traveljournal/domain/auth/controller/AuthController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.traveljournal.domain.auth.controller.docs.AuthControllerDocs;
 import com.traveljournal.domain.auth.dto.LoginCombinedResponse;
+import com.traveljournal.domain.auth.dto.LoginResponse;
 import com.traveljournal.domain.auth.service.AuthService;
 import com.traveljournal.domain.auth.util.EnumUtils;
 import com.traveljournal.domain.member.entity.SocialProvider;
@@ -31,7 +32,7 @@ public class AuthController implements AuthControllerDocs {
 
 	@GetMapping("/login/{socialProvider}/callback")
 	@Override
-	public ResponseEntity<?> socialCallback(
+	public ResponseEntity<LoginResponse> socialCallback(
 		@RequestParam String code,
 		@RequestParam(required = false) String deviceId,
 		@PathVariable String socialProvider,
@@ -48,7 +49,7 @@ public class AuthController implements AuthControllerDocs {
 
 	@PostMapping("/login/{socialProvider}/id-token")
 	@Override
-	public ResponseEntity<?> socialLoginWithIdToken(
+	public ResponseEntity<LoginResponse> socialLoginWithIdToken(
 		@RequestHeader("Authorization") String authorizationHeader,
 		@RequestParam(required = false) String deviceId,
 		@PathVariable String socialProvider,

--- a/src/main/java/com/traveljournal/domain/hashtag/entity/HashTag.java
+++ b/src/main/java/com/traveljournal/domain/hashtag/entity/HashTag.java
@@ -1,0 +1,25 @@
+package com.traveljournal.domain.hashtag.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "hashtag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HashTag {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(unique = true, nullable = false)
+	private String tagName;
+}

--- a/src/main/java/com/traveljournal/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/traveljournal/domain/journal/controller/JournalController.java
@@ -1,5 +1,6 @@
 package com.traveljournal.domain.journal.controller;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -14,6 +15,7 @@ import com.traveljournal.domain.journal.service.JournalService;
 import com.traveljournal.global.data.ApiResponseHandler;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -33,9 +35,11 @@ public class JournalController {
 	)
 	@GetMapping("/members/{memberId}/journals/region/{regionName}")
 	public ResponseEntity<Page<JournalListResponse>> findJournalsByRegionPaged(
+		@Parameter(description = "조회할 member_id")
 		@PathVariable Long memberId,
+		@Parameter(description = "수도권, 강원도, 충정도, 경상도, 전라도, 제주도")
 		@PathVariable String regionName,
-		@PageableDefault Pageable pageable) {
+		@ParameterObject @PageableDefault Pageable pageable) {
 		return ApiResponseHandler.getObjectSuccess(journalService.findJournalsByRegionWithPaging(regionName, pageable));
 	}
 
@@ -46,8 +50,9 @@ public class JournalController {
 	)
 	@GetMapping("/members/{memberId}/journals")
 	public ResponseEntity<Page<JournalListResponse>> findJournalsByMember(
+		@Parameter(description = "조회할 member_id")
 		@PathVariable Long memberId,
-		@PageableDefault Pageable pageable) {
+		@ParameterObject @PageableDefault Pageable pageable) {
 		return ApiResponseHandler.getObjectSuccess(journalService.findAllJournalsByMemberId(pageable));
 	}
 }

--- a/src/main/java/com/traveljournal/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/traveljournal/domain/journal/controller/JournalController.java
@@ -40,7 +40,7 @@ public class JournalController {
 		@Parameter(description = "수도권, 강원도, 충정도, 경상도, 전라도, 제주도")
 		@PathVariable String regionName,
 		@ParameterObject @PageableDefault Pageable pageable) {
-		return ApiResponseHandler.getObjectSuccess(journalService.findJournalsByRegionWithPaging(regionName, pageable));
+		return ApiResponseHandler.getObjectSuccess(journalService.findJournalsByRegionWithPaging(memberId, regionName, pageable));
 	}
 
 	@Operation(
@@ -53,6 +53,6 @@ public class JournalController {
 		@Parameter(description = "조회할 member_id")
 		@PathVariable Long memberId,
 		@ParameterObject @PageableDefault Pageable pageable) {
-		return ApiResponseHandler.getObjectSuccess(journalService.findAllJournalsByMemberId(pageable));
+		return ApiResponseHandler.getObjectSuccess(journalService.findAllJournalsByMemberId(memberId, pageable));
 	}
 }

--- a/src/main/java/com/traveljournal/domain/journal/dto/JournalListResponse.java
+++ b/src/main/java/com/traveljournal/domain/journal/dto/JournalListResponse.java
@@ -2,13 +2,22 @@ package com.traveljournal.domain.journal.dto;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record JournalListResponse(
+	@Schema(example = "1")
 	Long journalId,
+	@Schema(example = "[\"서울\", \"여행\", \"도심\"]")
 	List<String> hashTag,
+	@Schema(example = "서울 도심 속 힐링 명소 탐방기")
 	String title,
+	@Schema(example = "2")
 	Long nights,
+	@Schema(example = "3")
 	Long days,
+	@Schema(example = "2025.03.15")
 	String startDate,
+	@Schema(example = "2025.03.18")
 	String endDate
 ) {
 }

--- a/src/main/java/com/traveljournal/domain/journal/entity/Journal.java
+++ b/src/main/java/com/traveljournal/domain/journal/entity/Journal.java
@@ -1,0 +1,52 @@
+package com.traveljournal.domain.journal.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.traveljournal.domain.hashtag.entity.HashTag;
+import com.traveljournal.domain.member.entity.Member;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "Journal")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Journal {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String title;
+
+	private String region;
+	private Long nights;
+	private Long days;
+	private String startDate;
+	private String endDate;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@ManyToMany
+	@JoinTable(
+		name = "journal_hashtag",
+		joinColumns = @JoinColumn(name = "journal_id"),
+		inverseJoinColumns = @JoinColumn(name = "hashtag_id")
+	)
+	private List<HashTag>  hashTags = new ArrayList<>();
+}

--- a/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
@@ -16,6 +16,16 @@ public interface JournalRepository extends JpaRepository<Journal, Long> {
 	@Query("SELECT j.id FROM Journal j WHERE j.member.id = :memberId AND j.region IN :regions")
 	Page<Long> findIdsByMemberIdAndRegionIn(@Param("memberId") Long memberId, @Param("regions") List<String> regions, Pageable pageable);
 
+	@Query("""
+    SELECT DISTINCT j.id
+    FROM Journal j
+    LEFT JOIN j.hashTags h
+    WHERE j.title LIKE %:keyword%
+       OR j.region LIKE %:keyword%
+       OR h.tagName LIKE %:keyword%
+    """)
+	Page<Long> findIdsByTitleOrRegionOrHashTagContaining(@Param("keyword") String keyword, Pageable pageable);
+
 	// 2단계: fetch join으로 실제 데이터 조회
 	@Query("SELECT DISTINCT j FROM Journal j LEFT JOIN FETCH j.hashTags WHERE j.id IN :ids")
 	List<Journal> findAllByIdInFetchJoin(@Param("ids") List<Long> ids);

--- a/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
@@ -1,0 +1,25 @@
+package com.traveljournal.domain.journal.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.traveljournal.domain.journal.entity.Journal;
+
+public interface JournalRepository extends JpaRepository<Journal, Long> {
+
+	// 1단계: id만 페이징으로 조회
+	@Query("SELECT j.id FROM Journal j WHERE j.member.id = :memberId AND j.region IN :regions")
+	Page<Long> findIdsByMemberIdAndRegionIn(@Param("memberId") Long memberId, @Param("regions") List<String> regions, Pageable pageable);
+
+	// 2단계: fetch join으로 실제 데이터 조회
+	@Query("SELECT DISTINCT j FROM Journal j LEFT JOIN FETCH j.hashTags WHERE j.id IN :ids")
+	List<Journal> findAllByIdInFetchJoin(@Param("ids") List<Long> ids);
+
+	@Query("SELECT j.id FROM Journal j WHERE j.member.id = :memberId")
+	Page<Long> findIdsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
+++ b/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
@@ -1,38 +1,64 @@
 package com.traveljournal.domain.journal.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.traveljournal.domain.hashtag.entity.HashTag;
 import com.traveljournal.domain.journal.dto.JournalListResponse;
-import com.traveljournal.global.dummy.DummyDataProvider;
-import com.traveljournal.global.util.PaginationUtils;
+import com.traveljournal.domain.journal.entity.Journal;
+import com.traveljournal.domain.journal.repository.JournalRepository;
+import com.traveljournal.global.util.RegionGroupUtil;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class JournalService {
-	private final DummyDataProvider dummyDataProvider;
+
+	private final JournalRepository journalRepository;
 
 	@Transactional(readOnly = true)
-	public List<JournalListResponse> findJournalsByRegion(String regionName) {
-		return dummyDataProvider.getDummyJournalsByRegion(regionName);
+	public Page<JournalListResponse> findJournalsByRegionWithPaging(Long memberId, String regionName, Pageable pageable) {
+		List<String> regionList = RegionGroupUtil.getRegionList(regionName);
+		Page<Long> journalIdPage = journalRepository.findIdsByMemberIdAndRegionIn(memberId, regionList, pageable);
+		return getJournalListResponses(pageable, journalIdPage);
 	}
 
 	@Transactional(readOnly = true)
-	public Page<JournalListResponse> findJournalsByRegionWithPaging(String regionName, Pageable pageable) {
-		List<JournalListResponse> allData = findJournalsByRegion(regionName);
-		return PaginationUtils.getPagedList(allData, pageable);
+	public Page<JournalListResponse> findAllJournalsByMemberId(Long memberId, Pageable pageable) {
+		Page<Long> journalIdPage = journalRepository.findIdsByMemberId(memberId, pageable);
+		return getJournalListResponses(pageable, journalIdPage);
 	}
 
-	// MemberId추후 구현 필요
-	@Transactional(readOnly = true)
-	public Page<JournalListResponse> findAllJournalsByMemberId(Pageable pageable) {
-		List<JournalListResponse> allData = findJournalsByRegion("all");
-		return PaginationUtils.getPagedList(allData, pageable);
+	private Page<JournalListResponse> getJournalListResponses(Pageable pageable, Page<Long> journalIdPage) {
+		List<Long> journalIds = journalIdPage.getContent();
+
+		List<Journal> journals = journalRepository.findAllByIdInFetchJoin(journalIds);
+
+		Map<Long, Journal> journalMap = journals.stream().collect(Collectors.toMap(Journal::getId, j -> j));
+		List<Journal> sortedJournals = journalIds.stream().map(journalMap::get).toList();
+
+		return new PageImpl<>(
+			sortedJournals.stream()
+				.map(journal -> new JournalListResponse(
+					journal.getId(),
+					journal.getHashTags().stream().map(HashTag::getTagName).toList(),
+					journal.getTitle(),
+					journal.getNights(),
+					journal.getDays(),
+					journal.getStartDate(),
+					journal.getEndDate()
+				))
+				.toList(),
+			pageable,
+			journalIdPage.getTotalElements()
+		);
 	}
 }

--- a/src/main/java/com/traveljournal/domain/member/entity/Member.java
+++ b/src/main/java/com/traveljournal/domain/member/entity/Member.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.traveljournal.domain.journal.entity.Journal;
 import com.traveljournal.domain.place.entity.Place;
 
 import jakarta.persistence.Column;
@@ -61,6 +62,9 @@ public class Member {
 
 	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
 	private List<Place> places = new ArrayList<>();
+
+	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+	private List<Journal> journals = new ArrayList<>();
 
 	@PrePersist
 	public void prePersist() {

--- a/src/main/java/com/traveljournal/domain/member/entity/Member.java
+++ b/src/main/java/com/traveljournal/domain/member/entity/Member.java
@@ -1,9 +1,22 @@
 package com.traveljournal.domain.member.entity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.persistence.*;
+import com.traveljournal.domain.place.entity.Place;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,6 +58,9 @@ public class Member {
 
 	@OneToMany(mappedBy = "toMember", fetch = FetchType.LAZY)
 	private List<Follow> followers;
+
+	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+	private List<Place> places = new ArrayList<>();
 
 	@PrePersist
 	public void prePersist() {

--- a/src/main/java/com/traveljournal/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/traveljournal/domain/place/controller/PlaceController.java
@@ -40,7 +40,7 @@ public class PlaceController {
 		@Parameter(description = "수도권, 강원도, 충정도, 경상도, 전라도, 제주도")
 		@PathVariable String regionName,
 		@ParameterObject @PageableDefault Pageable pageable) {
-		return ApiResponseHandler.getObjectSuccess(placeService.findPlacesByRegionWithPagion(memberId, regionName, pageable));
+		return ApiResponseHandler.getObjectSuccess(placeService.findPlacesByRegionWithPaging(memberId, regionName, pageable));
 	}
 
 	@Operation(

--- a/src/main/java/com/traveljournal/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/traveljournal/domain/place/controller/PlaceController.java
@@ -36,7 +36,7 @@ public class PlaceController {
 		@PathVariable Long memberId,
 		@PathVariable String regionName,
 		@PageableDefault Pageable pageable) {
-		return ApiResponseHandler.getObjectSuccess(placeService.findPlacesByRegionWithPagion(regionName, pageable));
+		return ApiResponseHandler.getObjectSuccess(placeService.findPlacesByRegionWithPagion(memberId, regionName, pageable));
 	}
 
 	@Operation(
@@ -48,6 +48,6 @@ public class PlaceController {
 	public ResponseEntity<Page<PlaceListResponse>> findJournalsByMember(
 		@PathVariable Long memberId,
 		@PageableDefault Pageable pageable) {
-		return ApiResponseHandler.getObjectSuccess(placeService.findAllPlacesByMemberId(pageable));
+		return ApiResponseHandler.getObjectSuccess(placeService.findAllPlacesByMemberId(memberId, pageable));
 	}
 }

--- a/src/main/java/com/traveljournal/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/traveljournal/domain/place/controller/PlaceController.java
@@ -1,5 +1,6 @@
 package com.traveljournal.domain.place.controller;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -14,6 +15,7 @@ import com.traveljournal.domain.place.service.PlaceService;
 import com.traveljournal.global.data.ApiResponseHandler;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -33,9 +35,11 @@ public class PlaceController {
 	)
 	@GetMapping("/members/{memberId}/places/region/{regionName}")
 	public ResponseEntity<Page<PlaceListResponse>> findPlacesByRegionPaged(
+		@Parameter(description = "조회할 member_id")
 		@PathVariable Long memberId,
+		@Parameter(description = "수도권, 강원도, 충정도, 경상도, 전라도, 제주도")
 		@PathVariable String regionName,
-		@PageableDefault Pageable pageable) {
+		@ParameterObject @PageableDefault Pageable pageable) {
 		return ApiResponseHandler.getObjectSuccess(placeService.findPlacesByRegionWithPagion(memberId, regionName, pageable));
 	}
 
@@ -46,8 +50,9 @@ public class PlaceController {
 	)
 	@GetMapping("/members/{memberId}/places")
 	public ResponseEntity<Page<PlaceListResponse>> findJournalsByMember(
+		@Parameter(description = "조회할 member_id")
 		@PathVariable Long memberId,
-		@PageableDefault Pageable pageable) {
+		@ParameterObject @PageableDefault Pageable pageable) {
 		return ApiResponseHandler.getObjectSuccess(placeService.findAllPlacesByMemberId(memberId, pageable));
 	}
 }

--- a/src/main/java/com/traveljournal/domain/place/dto/PlaceListResponse.java
+++ b/src/main/java/com/traveljournal/domain/place/dto/PlaceListResponse.java
@@ -1,9 +1,15 @@
 package com.traveljournal.domain.place.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record PlaceListResponse(
+	@Schema(example = "1")
 	Long placeId,
+	@Schema(example = "서울 타워")
 	String title,
+	@Schema(example = "서울")
 	String region,
+	@Schema(example = "https://search.pstatic.net/common/?src=http%3A%2F%2Fblogfiles.naver.net%2FMjAyNTAzMjFfMTEw%2FMDAxNzQyNTU5MjY0OTkz.US8DxCfatYon23fMlPjPlqGIvpK8Zd8SIP3BuNFyGmUg.LUZS2bZBQ1aJuHyVI52EjhzHykDFewCj4mpJCeoV0G0g.JPEG%2F2025%25BA%25A2%25B2%25C9%25B0%25B3%25C8%25AD%25BD%25C3%25B1%25E2IMG_2503-009.JPG&type=sc960_832")
 	String thumbnailUrl
 ) {
 }

--- a/src/main/java/com/traveljournal/domain/place/entity/Place.java
+++ b/src/main/java/com/traveljournal/domain/place/entity/Place.java
@@ -1,0 +1,36 @@
+package com.traveljournal.domain.place.entity;
+
+import com.traveljournal.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "place")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Place {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String title;
+	private String region;
+	@Column(length = 512)
+	private String thumbnailUrl;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+}

--- a/src/main/java/com/traveljournal/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/traveljournal/domain/place/repository/PlaceRepository.java
@@ -1,13 +1,25 @@
 package com.traveljournal.domain.place.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.traveljournal.domain.place.entity.Place;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
-	Page<Place> findByMemberIdAndRegionContaining(Long memberId, String region, Pageable pageable);
+	// 1단계: id만 페이징으로 조회
+	@Query("SELECT p.id FROM Place p WHERE p.member.id = :memberId AND p.region IN :regions")
+	Page<Long> findIdsByMemberIdAndRegionIn(@Param("memberId") Long memberId, @Param("regions") List<String> regions, Pageable pageable);
 
-	Page<Place> findByMemberId(Long memberId, Pageable pageable);
+	// 2단계: 실제 데이터 조회
+	@Query("SELECT p FROM Place p WHERE p.id IN :ids")
+	List<Place> findAllByIdIn(@Param("ids") List<Long> ids);
+
+	// 전체 조회 (단일 회원)
+	@Query("SELECT p.id FROM Place p WHERE p.member.id = :memberId")
+	Page<Long> findIdsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/traveljournal/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/traveljournal/domain/place/repository/PlaceRepository.java
@@ -11,9 +11,13 @@ import org.springframework.data.repository.query.Param;
 import com.traveljournal.domain.place.entity.Place;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
-	// 1단계: id만 페이징으로 조회
+	// 1단계: id만 페이징으로 조회 Place
 	@Query("SELECT p.id FROM Place p WHERE p.member.id = :memberId AND p.region IN :regions")
 	Page<Long> findIdsByMemberIdAndRegionIn(@Param("memberId") Long memberId, @Param("regions") List<String> regions, Pageable pageable);
+
+	// 1단계: id만 페이징으로 검색 PlaceSearch
+	@Query("SELECT p.id FROM Place p WHERE p.title LIKE %:keyword% OR p.region LIKE %:keyword%")
+	Page<Long> findIdsByTitleOrRegionContaining(@Param("keyword") String keyword, Pageable pageable);
 
 	// 2단계: 실제 데이터 조회
 	@Query("SELECT p FROM Place p WHERE p.id IN :ids")
@@ -22,4 +26,6 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 	// 전체 조회 (단일 회원)
 	@Query("SELECT p.id FROM Place p WHERE p.member.id = :memberId")
 	Page<Long> findIdsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+
 }

--- a/src/main/java/com/traveljournal/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/traveljournal/domain/place/repository/PlaceRepository.java
@@ -1,0 +1,13 @@
+package com.traveljournal.domain.place.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.traveljournal.domain.place.entity.Place;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+	Page<Place> findByMemberIdAndRegionContaining(Long memberId, String region, Pageable pageable);
+
+	Page<Place> findByMemberId(Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/traveljournal/domain/place/service/PlaceService.java
+++ b/src/main/java/com/traveljournal/domain/place/service/PlaceService.java
@@ -1,6 +1,11 @@
 package com.traveljournal.domain.place.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.traveljournal.domain.place.dto.PlaceListResponse;
 import com.traveljournal.domain.place.entity.Place;
 import com.traveljournal.domain.place.repository.PlaceRepository;
+import com.traveljournal.global.util.RegionGroupUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,25 +24,37 @@ public class PlaceService {
 	private final PlaceRepository placeRepository;
 
 	@Transactional(readOnly = true)
-	public Page<PlaceListResponse> findPlacesByRegionWithPagion(Long memberId, String regionName, Pageable pageable) {
-		Page<Place> places = placeRepository.findByMemberIdAndRegionContaining(memberId, regionName, pageable);
-		return places.map(place -> new PlaceListResponse(
-			place.getId(),
-			place.getTitle(),
-			place.getRegion(),
-			place.getThumbnailUrl()
-		));
+	public Page<PlaceListResponse> findPlacesByRegionWithPaging(Long memberId, String regionName, Pageable pageable) {
+		List<String> regionList = RegionGroupUtil.getRegionList(regionName);
+
+		Page<Long> placeIdPage = placeRepository.findIdsByMemberIdAndRegionIn(memberId, regionList, pageable);
+		return getPlaceListResponses(pageable, placeIdPage);
 	}
 
 	@Transactional(readOnly = true)
 	public Page<PlaceListResponse> findAllPlacesByMemberId(Long memberId, Pageable pageable) {
-		// 회원별 플레이스 조회 로직 필요시 구현
-		Page<Place> places = placeRepository.findByMemberId(memberId, pageable);
-		return places.map(place -> new PlaceListResponse(
-			place.getId(),
-			place.getTitle(),
-			place.getRegion(),
-			place.getThumbnailUrl()
-		));
+		Page<Long> placeIdPage = placeRepository.findIdsByMemberId(memberId, pageable);
+		return getPlaceListResponses(pageable, placeIdPage);
+	}
+
+	private Page<PlaceListResponse> getPlaceListResponses(Pageable pageable, Page<Long> placeIdPage) {
+		List<Long> placeIds = placeIdPage.getContent();
+		List<Place> places = placeRepository.findAllByIdIn(placeIds);
+
+		Map<Long, Place> placeMap = places.stream().collect(Collectors.toMap(Place::getId, p -> p));
+		List<Place> sortedPlaces = placeIds.stream().map(placeMap::get).toList();
+
+		return new PageImpl<>(
+			sortedPlaces.stream()
+				.map(place -> new PlaceListResponse(
+					place.getId(),
+					place.getTitle(),
+					place.getRegion(),
+					place.getThumbnailUrl()
+				))
+				.toList(),
+			pageable,
+			placeIdPage.getTotalElements()
+		);
 	}
 }

--- a/src/main/java/com/traveljournal/domain/place/service/PlaceService.java
+++ b/src/main/java/com/traveljournal/domain/place/service/PlaceService.java
@@ -1,15 +1,13 @@
 package com.traveljournal.domain.place.service;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.traveljournal.domain.place.dto.PlaceListResponse;
-import com.traveljournal.global.dummy.DummyDataProvider;
-import com.traveljournal.global.util.PaginationUtils;
+import com.traveljournal.domain.place.entity.Place;
+import com.traveljournal.domain.place.repository.PlaceRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,21 +15,28 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PlaceService {
 
-	private final DummyDataProvider dummyDataProvider;
+	private final PlaceRepository placeRepository;
 
-	private List<PlaceListResponse> findPlacesByRegion(String regionName) {
-		return dummyDataProvider.getDummyPlacesByRegion(regionName);
+	@Transactional(readOnly = true)
+	public Page<PlaceListResponse> findPlacesByRegionWithPagion(Long memberId, String regionName, Pageable pageable) {
+		Page<Place> places = placeRepository.findByMemberIdAndRegionContaining(memberId, regionName, pageable);
+		return places.map(place -> new PlaceListResponse(
+			place.getId(),
+			place.getTitle(),
+			place.getRegion(),
+			place.getThumbnailUrl()
+		));
 	}
 
 	@Transactional(readOnly = true)
-	public Page<PlaceListResponse> findPlacesByRegionWithPagion(String regionName, Pageable pageable) {
-		List<PlaceListResponse> allData = findPlacesByRegion(regionName);
-		return PaginationUtils.getPagedList(allData, pageable);
-	}
-
-	@Transactional(readOnly = true)
-	public Page<PlaceListResponse> findAllPlacesByMemberId(Pageable pageable) {
-		List<PlaceListResponse> allData = findPlacesByRegion("all");
-		return PaginationUtils.getPagedList(allData, pageable);
+	public Page<PlaceListResponse> findAllPlacesByMemberId(Long memberId, Pageable pageable) {
+		// 회원별 플레이스 조회 로직 필요시 구현
+		Page<Place> places = placeRepository.findByMemberId(memberId, pageable);
+		return places.map(place -> new PlaceListResponse(
+			place.getId(),
+			place.getTitle(),
+			place.getRegion(),
+			place.getThumbnailUrl()
+		));
 	}
 }

--- a/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
+++ b/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
@@ -30,7 +30,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Valid
 @RequestMapping("/v1/search")
-@Tag(name = "Search API", description = "사용자 검색")
+@Tag(name = "Search API", description = "검색 API")
 public class SearchController {
 
 	private final MemberSearchService memberSearchService;

--- a/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
+++ b/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
@@ -1,5 +1,6 @@
 package com.traveljournal.domain.search.controller;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -9,13 +10,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.traveljournal.domain.journal.dto.JournalListResponse;
 import com.traveljournal.domain.place.dto.PlaceListResponse;
 import com.traveljournal.domain.search.dto.MemberSearchResponse;
+import com.traveljournal.domain.search.service.JournalSearchService;
 import com.traveljournal.domain.search.service.MemberSearchService;
 import com.traveljournal.domain.search.service.PlaceSearchService;
 import com.traveljournal.global.data.ApiResponseHandler;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -31,6 +35,7 @@ public class SearchController {
 
 	private final MemberSearchService memberSearchService;
 	private final PlaceSearchService placeSearchService;
+	private final JournalSearchService journalSearchService;
 
 	@GetMapping("/members")
 	@Operation(
@@ -59,10 +64,27 @@ public class SearchController {
 	)
 	@GetMapping("/places")
 	public ResponseEntity<Page<PlaceListResponse>> searchPlaces(
+		@Parameter(description = "타이틀, 지역")
 		@RequestParam String keyword,
-		@PageableDefault Pageable pageable) {
+		@ParameterObject @PageableDefault Pageable pageable) {
 
 		Page<PlaceListResponse> result = placeSearchService.searchPlaces(keyword, pageable);
+
+		return ApiResponseHandler.getObjectSuccess(result);
+	}
+
+	@Operation(
+		summary = "여행일지 검색",
+		description = "키워드로 여행일지 검색",
+		security = @SecurityRequirement(name = "bearer-key")
+	)
+	@GetMapping("/journals")
+	public ResponseEntity<Page<JournalListResponse>> searchJournals(
+		@Parameter(description = "타이틀, 지역, 해시태그")
+		@RequestParam String keyword,
+		@ParameterObject @PageableDefault Pageable pageable) {
+
+		Page<JournalListResponse> result = journalSearchService.searchJournals(keyword, pageable);
 
 		return ApiResponseHandler.getObjectSuccess(result);
 	}

--- a/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
+++ b/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
@@ -9,8 +9,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.traveljournal.domain.place.dto.PlaceListResponse;
 import com.traveljournal.domain.search.dto.MemberSearchResponse;
 import com.traveljournal.domain.search.service.MemberSearchService;
+import com.traveljournal.domain.search.service.PlaceSearchService;
 import com.traveljournal.global.data.ApiResponseHandler;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,17 +29,17 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Search API", description = "사용자 검색")
 public class SearchController {
 
-    private final MemberSearchService memberSearchService;
+	private final MemberSearchService memberSearchService;
+	private final PlaceSearchService placeSearchService;
 
-    @GetMapping("/members")
-    @Operation(
-            summary = "사용자 검색",
-            description = "사용자가 입력한 키워드로 다른 사용자를 검색합니다.",
-            security = @SecurityRequirement(name = "bearer-key"))
-    public ResponseEntity<Page<MemberSearchResponse>> searchMembers(
-            @RequestParam @NotBlank(message = "검색어는 비어 있을 수 없습니다.") String keyword,
-            @PageableDefault(sort = "nickname") Pageable pageable)
-    {
+	@GetMapping("/members")
+	@Operation(
+		summary = "사용자 검색",
+		description = "사용자가 입력한 키워드로 다른 사용자를 검색합니다.",
+		security = @SecurityRequirement(name = "bearer-key"))
+	public ResponseEntity<Page<MemberSearchResponse>> searchMembers(
+		@RequestParam @NotBlank(message = "검색어는 비어 있을 수 없습니다.") String keyword,
+		@PageableDefault(sort = "nickname") Pageable pageable) {
 /*
         // 키워드가 비어 있을 경우, 409 상태 코드로 실패 메시지 반환
         if (keyword == null || keyword.isEmpty()) {
@@ -45,8 +47,23 @@ public class SearchController {
         }
 
  */
-        Page<MemberSearchResponse> result = memberSearchService.searchMembers(keyword, pageable);
+		Page<MemberSearchResponse> result = memberSearchService.searchMembers(keyword, pageable);
 
-        return ApiResponseHandler.getObjectSuccess(result);
-    }
+		return ApiResponseHandler.getObjectSuccess(result);
+	}
+
+	@Operation(
+		summary = "플레이스 검색",
+		description = "키워드로 플레이스 검색",
+		security = @SecurityRequirement(name = "bearer-key")
+	)
+	@GetMapping("/places")
+	public ResponseEntity<Page<PlaceListResponse>> searchPlaces(
+		@RequestParam String keyword,
+		@PageableDefault Pageable pageable) {
+
+		Page<PlaceListResponse> result = placeSearchService.searchPlaces(keyword, pageable);
+
+		return ApiResponseHandler.getObjectSuccess(result);
+	}
 }

--- a/src/main/java/com/traveljournal/domain/search/service/JournalSearchService.java
+++ b/src/main/java/com/traveljournal/domain/search/service/JournalSearchService.java
@@ -1,0 +1,55 @@
+package com.traveljournal.domain.search.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.traveljournal.domain.hashtag.entity.HashTag;
+import com.traveljournal.domain.journal.dto.JournalListResponse;
+import com.traveljournal.domain.journal.entity.Journal;
+import com.traveljournal.domain.journal.repository.JournalRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class JournalSearchService {
+	private final JournalRepository journalRepository;
+
+	@Transactional(readOnly = true)
+	public Page<JournalListResponse> searchJournals(String keyword, Pageable pageable) {
+
+		Page<Long> journalIdPage = journalRepository.findIdsByTitleOrRegionOrHashTagContaining(keyword, pageable);
+		List<Long> journalIds = journalIdPage.getContent();
+
+		List<Journal> journals = journalRepository.findAllByIdInFetchJoin(journalIds);
+
+		Map<Long, Journal> journalMap = journals.stream()
+			.collect(Collectors.toMap(Journal::getId, j -> j));
+		List<Journal> sortedJournals = journalIds.stream()
+			.map(journalMap::get)
+			.toList();
+
+		return new PageImpl<>(
+			sortedJournals.stream()
+				.map(journal -> new JournalListResponse(
+					journal.getId(),
+					journal.getHashTags().stream().map(HashTag::getTagName).toList(),
+					journal.getTitle(),
+					journal.getNights(),
+					journal.getDays(),
+					journal.getStartDate(),
+					journal.getEndDate()
+				))
+				.toList(),
+			pageable,
+			journalIdPage.getTotalElements()
+		);
+	}
+}

--- a/src/main/java/com/traveljournal/domain/search/service/PlaceSearchService.java
+++ b/src/main/java/com/traveljournal/domain/search/service/PlaceSearchService.java
@@ -1,0 +1,50 @@
+package com.traveljournal.domain.search.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.traveljournal.domain.place.dto.PlaceListResponse;
+import com.traveljournal.domain.place.entity.Place;
+import com.traveljournal.domain.place.repository.PlaceRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceSearchService {
+
+	private final PlaceRepository placeRepository;
+
+	@Transactional(readOnly = true)
+	public Page<PlaceListResponse> searchPlaces(String keyword, Pageable pageable) {
+		Page<Long> placeIdPage = placeRepository.findIdsByTitleOrRegionContaining(keyword, pageable);
+		List<Long> placeIds = placeIdPage.getContent();
+		List<Place> places = placeRepository.findAllByIdIn(placeIds);
+
+		Map<Long, Place> placeMap = places.stream()
+			.collect(Collectors.toMap(Place::getId, p -> p));
+		List<Place> sortedPlaces = placeIds.stream()
+			.map(placeMap::get)
+			.toList();
+
+		return new PageImpl<>(
+			sortedPlaces.stream()
+				.map(place -> new PlaceListResponse(
+					place.getId(),
+					place.getTitle(),
+					place.getRegion(),
+					place.getThumbnailUrl()
+				))
+				.toList(),
+			pageable,
+			placeIdPage.getTotalElements()
+		);
+	}
+}

--- a/src/main/java/com/traveljournal/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/traveljournal/global/security/jwt/JwtAuthenticationFilter.java
@@ -46,10 +46,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 					if (status == JwtValidateStatus.ACCEPTED) {
 						jwtTokenProvider.setAuthentication(token);
-						log.error("토큰 인증 성공");
 					} else if (status == JwtValidateStatus.EXPIRED) {
 						request.setAttribute("exception", "TOKEN_EXPIRED");
-						log.error("토큰 만료");
 						SecurityContextHolder.clearContext();
 					} else if (status == JwtValidateStatus.INVALID) {
 						request.setAttribute("exception", "TOKEN_INVALID");

--- a/src/main/java/com/traveljournal/global/util/RegionGroupUtil.java
+++ b/src/main/java/com/traveljournal/global/util/RegionGroupUtil.java
@@ -1,0 +1,20 @@
+package com.traveljournal.global.util;
+
+import java.util.List;
+import java.util.Map;
+
+public class RegionGroupUtil {
+
+	public static final Map<String, List<String>> REGION_GROUP_MAP = Map.of(
+		"수도권", List.of("서울", "경기", "인천", "경기도"),
+		"강원도", List.of("강원도"),
+		"충청도", List.of("충청북도", "충청남도", "충북", "충남", "충청도"),
+		"전라도", List.of("전라북도", "전라남도", "전북", "전남", "전라도"),
+		"제주도", List.of("제주도", "제주"),
+		"경상도", List.of("경상북도", "경상남도", "경남", "경북", "경상도")
+	);
+
+	public static List<String> getRegionList(String regionGroup) {
+		return REGION_GROUP_MAP.getOrDefault(regionGroup, List.of(regionGroup));
+	}
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
-    url: jdbc:mysql://mysql:3306/traveljournal_db
-    username: app_user
+    url: jdbc:mysql://${secret.prod-db-endpoint}:3306/traveljournal_db
+    username: root
     password: ${secret.prod-password}
     driver-class-name: com.mysql.cj.jdbc.Driver
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://${secret.prod-db-endpoint}:3306/traveljournal_db
+    url: jdbc:mysql://${secret.prod-db-endpoint}:3306/traveljournal_db?serverTimezone=Asia/Seoul
     username: root
     password: ${secret.prod-password}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,10 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul
   servlet:
     multipart:
       max-file-size: 5MB # 한개 파일의 최대 사이즈 (default: 1MB)


### PR DESCRIPTION
## 🔥 해결된 이슈
- Closes #36 
- JIRA # TJFE-162, TJFE-163
## 📌 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련된 테스트를 추가하거나 기존 테스트를 실행하여 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드를 따랐는지 확인했습니다.
- [x] 배포가 필요한 경우 관련 작업을 완료했습니다. (예: CI/CD 설정, 환경 변수 추가 등)

## ✨ 작업 내용
- 애플리케이션 내부에서 생성하던 더미데이터를 실제 데이터베이스에 데이터로 저장하여 구현하였습니다.
> 기존 사용하던 더미데이터는 혹시 모를 테스트 데이터를 위해 남겨두었습니다.
- 검색 기능 구현 : 플레이스
> 현재 member_id = 1 회원에만 데이터를 넣어놓았기때문에 다른 회원에서는 데이터가 조회되지 않는 것이 정상입니다.
검색 되는 내용은 타이틀과 지역을 검색하여 반환합니다.
만약 빈 값으로 넣는다면 모든 데이터를 조회하게 됩니다. page이기 때문에 해당 page만큼만 조회하여 리소스를 많이 쓰지 않도록 구현하였습니다.
- 검색 기능 구현 : 여행일지
> 위와 동일합니다.
검색 되는 내용은 타이틀과 지역 그리고 해시태그입니다. 해시태그의 경우 플레이스에는 존재하지 않기때문에 여행일지에만 구현해두었습니다.
- 지역구를 통한 플레이스, 여행일지 검색기능
> 원래 더미데이터로 제공하던 내용을 실제 데이터로 변경하였기때문에 member 1번 회원(AWS 데이터베이스)만 더미데이터가 존재합니다.
- 지역구 검색시 지역반환값 기능 추가
> 예시 : 수도권으로 들어왔을때 데이터베이스에 서울, 경기, 인천, 경기도 이런형식으로 되어있는 것을 검색하여 반환하는 기능입니다.
- 타임존 변경
> EC2 내부와 RDS MySQL 내부 타임존 시간을 Asia/Seoul로 통일하여 데이터를 저장할때 서울 표준 시간으로 저장하도록 하였습니다.
추후 몽고DB가 구현되었을경우에는 UTC로 저장해야한다고 하니 참고바랍니다. 몽고DB에 저장된 시간을 쓰려면 서울 표준 시간으로 바꿔서 제공해야합니다.

## 🚀 추가 설명
> 페이지 구현시 @ParameterObject를 사용하여 스웨거 설명을 표준화시켜주시면 될 것 같습니다.
서버의 데이터베이스를 접근하려면 무조건 ssh를 이용하여 ec2를 경유해서 사용해야합니다! (AWS)

## 📸 테스트 결과 (스크린샷 혹은 로그)
> [스크린샷 혹은 테스트 정상 확인 로그를 첨부해주세요.]
![Pasted Graphic 8](https://github.com/user-attachments/assets/7861ced8-76ad-4167-8863-f588153b8658)
![Pasted Graphic 10](https://github.com/user-attachments/assets/537a298a-4d81-4519-b64a-12f2abe467d0)
![Pasted Graphic 9](https://github.com/user-attachments/assets/50250b04-7ea7-4e48-8cfc-8dc7b8713790)
![Pasted Graphic 12](https://github.com/user-attachments/assets/dde80a26-326f-436b-8a1b-7071486cb578)