### PR TITLE
[Feature] 탐험하기(여행일지) 기능 구현 #41

### DIFF
--- a/src/main/java/com/traveljournal/TravelJournalApplication.java
+++ b/src/main/java/com/traveljournal/TravelJournalApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 @EnableFeignClients
+@EnableScheduling
 @SpringBootApplication
 public class TravelJournalApplication {
 

--- a/src/main/java/com/traveljournal/domain/explore/controller/ExploreController.java
+++ b/src/main/java/com/traveljournal/domain/explore/controller/ExploreController.java
@@ -1,0 +1,65 @@
+package com.traveljournal.domain.explore.controller;
+
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.traveljournal.domain.explore.dto.ExploreJournalFeedResponse;
+import com.traveljournal.domain.explore.service.ExploreFeedService;
+import com.traveljournal.domain.journal.dto.JournalIdListRequest;
+import com.traveljournal.global.data.ApiResponseHandler;
+import com.traveljournal.global.security.util.SecurityUtil;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/explore")
+@Tag(name = "Explore API")
+public class ExploreController {
+
+	private final ExploreFeedService exploreFeedService;
+
+	@Operation(
+		summary = "Explore Journals",
+		description = """
+			탐험하기 여행일지 리스트입니다.
+			<br> 팔로우한 회원이 존재하고, 팔로우한 회원이 올린 게시물을 읽지 않았다면 최근에 올린 게시글 위주로 보여줍니다.
+			<br> 팔로우한 회원이 존재하지만 게시글을 모두 읽었거나 팔로우한 회원의 게시글이 없다면 비팔로우 회원의 게시글을 랜덤하게 보여줍니다.
+			<br>  팔로우한 회원이 없으면 비팔로우 회원의 게시글을 랜덤하게 보여줍니다.""",
+		security = @SecurityRequirement(name = "bearer-key")
+	)
+	@GetMapping("/journals/feed")
+	public ResponseEntity<Page<ExploreJournalFeedResponse>> findFollowingJournalFeed(
+		@ParameterObject @PageableDefault Pageable pageable
+	) {
+		Long memberId = SecurityUtil.getCurrentMemberId();
+		Page<ExploreJournalFeedResponse> result = exploreFeedService.getExploreFeed(memberId, pageable);
+
+		return ApiResponseHandler.getObjectSuccess(result);
+	}
+
+	@Operation(
+		summary = "mark Journal as seen",
+		description = "탐험하기 여행일지를 보았을때 기능입니다.",
+		security = @SecurityRequirement(name = "bearer-key")
+	)
+	@PostMapping("/journals/seen")
+	public ResponseEntity<?> markJournalAsSeen(
+		@RequestBody JournalIdListRequest request
+	) {
+		Long memberId = SecurityUtil.getCurrentMemberId();
+		exploreFeedService.markJournalsAsSeen(memberId, request.journalIds());
+		return ApiResponseHandler.onSuccess("");
+	}
+}

--- a/src/main/java/com/traveljournal/domain/explore/dto/ExploreJournalFeedResponse.java
+++ b/src/main/java/com/traveljournal/domain/explore/dto/ExploreJournalFeedResponse.java
@@ -1,0 +1,61 @@
+package com.traveljournal.domain.explore.dto;
+
+import java.util.List;
+
+import com.traveljournal.domain.hashtag.entity.HashTag;
+import com.traveljournal.domain.journal.entity.Journal;
+import com.traveljournal.domain.member.entity.Member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record ExploreJournalFeedResponse(
+	@Schema(example = "1")
+	Long journalId,
+	@Schema(example = "춘천 맛집 투어와 남이섬 산책")
+	String title,
+	@Schema(example = "[\"강원도\", \"춘천\", \"닭갈비\"]")
+	List<String> hashTag,
+	@Schema(example = "강원도")
+	String region,
+	@Schema(example = "1")
+	Long nights,
+	@Schema(example = "2")
+	Long days,
+	@Schema(example = "2025.04.01")
+	String startDate,
+	@Schema(example = "2025.04.03")
+	String endDate,
+	@Schema(example = "https://image.dongascience.com/Photo/2020/03/5bddba7b6574b95d37b6079c199d7101.jpg")
+	String 	thumbnailUrl,
+	@Schema(example = "100")
+	Long likeCount,
+	@Schema(example = "972")
+	Long commentCount,
+	@Schema(example = "1")
+	Long memberId,
+	@Schema(example = "도요새")
+	String nickname,
+	@Schema(example = "https://travel-journal-s3.s3.amazonaws.com/default/profile/default1.png")
+	String profileImageUrl
+) {
+	public static ExploreJournalFeedResponse of(Journal journal, Member member) {
+		return ExploreJournalFeedResponse.builder()
+			.journalId(journal.getId())
+			.title(journal.getTitle())
+			.hashTag(journal.getHashTags().stream().map(HashTag::getTagName).toList())
+			.region(journal.getRegion())
+			.nights(journal.getNights())
+			.days(journal.getDays())
+			.startDate(journal.getStartDate())
+			.endDate(journal.getEndDate())
+			.thumbnailUrl(journal.getThumbnailUrl())
+			.likeCount(100L)
+			.commentCount(972L)
+			.memberId(member.getId())
+			.nickname(member.getNickname())
+			.profileImageUrl(member.getProfileImageUrl())
+			.build();
+	}
+}

--- a/src/main/java/com/traveljournal/domain/explore/entity/ExploreSeenJournal.java
+++ b/src/main/java/com/traveljournal/domain/explore/entity/ExploreSeenJournal.java
@@ -1,0 +1,38 @@
+package com.traveljournal.domain.explore.entity;
+
+import com.traveljournal.domain.journal.entity.Journal;
+import com.traveljournal.domain.member.entity.Member;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExploreSeenJournal {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "journal_id")
+	private Journal journal;
+
+	private java.time.LocalDateTime seenAt;
+}

--- a/src/main/java/com/traveljournal/domain/explore/repository/ExploreSeenJournalRepository.java
+++ b/src/main/java/com/traveljournal/domain/explore/repository/ExploreSeenJournalRepository.java
@@ -1,8 +1,10 @@
 package com.traveljournal.domain.explore.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,4 +17,8 @@ public interface ExploreSeenJournalRepository extends JpaRepository<ExploreSeenJ
 
 	@Query("SELECT esj.journal.id FROM ExploreSeenJournal esj WHERE esj.member.id = :memberId AND esj.journal.id IN :journalIds")
 	List<Long> findSeenJournalIdsByMemberIdAndJournalIds(@Param("memberId") Long memberId, @Param("journalIds") List<Long> journalIds);
+
+	@Modifying
+	@Query("DELETE FROM ExploreSeenJournal esj WHERE esj.seenAt < :cutoff")
+	void deleteAllBySeenAtBefore(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/traveljournal/domain/explore/repository/ExploreSeenJournalRepository.java
+++ b/src/main/java/com/traveljournal/domain/explore/repository/ExploreSeenJournalRepository.java
@@ -1,0 +1,18 @@
+package com.traveljournal.domain.explore.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.traveljournal.domain.explore.entity.ExploreSeenJournal;
+
+public interface ExploreSeenJournalRepository extends JpaRepository<ExploreSeenJournal, Long> {
+
+	@Query("SELECT esj.journal.id FROM ExploreSeenJournal esj WHERE esj.member.id = :memberId")
+	List<Long> findSeenJournalIdsByMemberId(@Param("memberId") Long memberId);
+
+	@Query("SELECT esj.journal.id FROM ExploreSeenJournal esj WHERE esj.member.id = :memberId AND esj.journal.id IN :journalIds")
+	List<Long> findSeenJournalIdsByMemberIdAndJournalIds(@Param("memberId") Long memberId, @Param("journalIds") List<Long> journalIds);
+}

--- a/src/main/java/com/traveljournal/domain/explore/service/ExploreFeedService.java
+++ b/src/main/java/com/traveljournal/domain/explore/service/ExploreFeedService.java
@@ -1,0 +1,94 @@
+package com.traveljournal.domain.explore.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.traveljournal.domain.explore.dto.ExploreJournalFeedResponse;
+import com.traveljournal.domain.explore.entity.ExploreSeenJournal;
+import com.traveljournal.domain.explore.repository.ExploreSeenJournalRepository;
+import com.traveljournal.domain.journal.entity.Journal;
+import com.traveljournal.domain.journal.repository.JournalRepository;
+import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.repository.FollowRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ExploreFeedService {
+
+	private final FollowRepository followRepository;
+	private final JournalRepository journalRepository;
+	private final ExploreSeenJournalRepository exploreSeenJournalRepository;
+
+	@Transactional(readOnly = true)
+	public Page<ExploreJournalFeedResponse> getExploreFeed(Long memberId, Pageable pageable) {
+		List<Long> followingIds = followRepository.findAcceptedToMemberIdsByFromMemberId(memberId);
+
+		List<Long> seenJournalIds = exploreSeenJournalRepository.findSeenJournalIdsByMemberId(memberId);
+
+		Page<Long> followedJournalIds = (seenJournalIds == null || seenJournalIds.isEmpty())
+			? journalRepository.findIdsByMemberIdInOrderByCreatedAtDesc(followingIds, pageable)
+			: journalRepository.findIdsByMemberIdInAndIdNotInOrderByCreatedAtDesc(followingIds, seenJournalIds, pageable);
+
+		List<Journal> followedJournals = followedJournalIds.isEmpty()
+			? List.of()
+			: journalRepository.findAllByIdInFetchJoin(followedJournalIds.getContent());
+
+		Map<Long, Journal> journalMap = followedJournals.stream()
+			.collect(Collectors.toMap(Journal::getId, j -> j));
+		List<Journal> sortedFollowedJournals = followedJournalIds.getContent().stream()
+			.map(journalMap::get)
+			.filter(Objects::nonNull)
+			.toList();
+
+		List<Long> notFollowMemberIds = Stream.concat(followingIds.stream(), Stream.of(memberId)).toList();
+		int limit = pageable.getPageSize();
+
+		List<Long> notFollowedJournalIds = (seenJournalIds == null || seenJournalIds.isEmpty())
+			? journalRepository.findRandomIdsByMemberIdNotInAndIdNotIn(notFollowMemberIds, List.of(), limit)
+			: journalRepository.findRandomIdsByMemberIdNotInAndIdNotIn(notFollowMemberIds, seenJournalIds, limit);
+
+		List<Journal> notFollowedJournals = notFollowedJournalIds.isEmpty()
+			? List.of()
+			: journalRepository.findAllByIdInFetchJoin(notFollowedJournalIds);
+
+		List<ExploreJournalFeedResponse> feed = Stream.concat(
+			sortedFollowedJournals.stream().map(j -> ExploreJournalFeedResponse.of(j, j.getMember())),
+			notFollowedJournals.stream().map(j -> ExploreJournalFeedResponse.of(j, j.getMember()))
+		).toList();
+
+		return new PageImpl<>(feed, pageable, followedJournalIds.getTotalElements() + notFollowedJournalIds.size());
+	}
+
+	@Transactional
+	public void markJournalsAsSeen(Long memberId, List<Long> journalIds) {
+		List<Long> alreadySeen = exploreSeenJournalRepository.findSeenJournalIdsByMemberIdAndJournalIds(memberId, journalIds);
+
+		List<Long> toSave = journalIds.stream()
+			.filter(id -> !alreadySeen.contains(id))
+			.toList();
+
+		List<ExploreSeenJournal> entities = toSave.stream()
+			.map(journalId -> ExploreSeenJournal.builder()
+				.member(Member.builder().id(memberId).build())
+				.journal(Journal.builder().id(journalId).build())
+				.seenAt(LocalDateTime.now())
+				.build())
+			.toList();
+
+		if (!entities.isEmpty()) {
+			exploreSeenJournalRepository.saveAll(entities);
+		}
+	}
+}

--- a/src/main/java/com/traveljournal/domain/explore/service/ExploreFeedService.java
+++ b/src/main/java/com/traveljournal/domain/explore/service/ExploreFeedService.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,5 +91,12 @@ public class ExploreFeedService {
 		if (!entities.isEmpty()) {
 			exploreSeenJournalRepository.saveAll(entities);
 		}
+	}
+
+	@Scheduled(cron = "0 0 3 * * *")
+	@Transactional
+	public void deleteOldSeenJournals() {
+		LocalDateTime cutoff = LocalDateTime.now().minusDays(3);
+		exploreSeenJournalRepository.deleteAllBySeenAtBefore(cutoff);
 	}
 }

--- a/src/main/java/com/traveljournal/domain/journal/dto/JournalIdListRequest.java
+++ b/src/main/java/com/traveljournal/domain/journal/dto/JournalIdListRequest.java
@@ -1,0 +1,10 @@
+package com.traveljournal.domain.journal.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record JournalIdListRequest(
+	@Schema(description = "읽은 여행일지 ID 리스트", example = "[1,2,3]")
+	List<Long> journalIds
+) {}

--- a/src/main/java/com/traveljournal/domain/journal/entity/Journal.java
+++ b/src/main/java/com/traveljournal/domain/journal/entity/Journal.java
@@ -1,11 +1,13 @@
 package com.traveljournal.domain.journal.entity;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import com.traveljournal.domain.hashtag.entity.HashTag;
 import com.traveljournal.domain.member.entity.Member;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -17,6 +19,8 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,6 +28,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "Journal")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Journal {
 
 	@Id
@@ -37,6 +43,10 @@ public class Journal {
 	private Long days;
 	private String startDate;
 	private String endDate;
+	private LocalDateTime createdAt;
+
+	@Column(length = 512)
+	private String thumbnailUrl;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
@@ -32,4 +32,17 @@ public interface JournalRepository extends JpaRepository<Journal, Long> {
 
 	@Query("SELECT j.id FROM Journal j WHERE j.member.id = :memberId")
 	Page<Long> findIdsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+	@Query("SELECT j.id FROM Journal j WHERE j.member.id IN :memberIds ORDER BY j.createdAt DESC")
+	Page<Long> findIdsByMemberIdInOrderByCreatedAtDesc(@Param("memberIds") List<Long> memberIds, Pageable pageable);
+
+	@Query("SELECT j.id FROM Journal j WHERE j.member.id IN :memberIds AND j.id NOT IN :excludeJournalIds ORDER BY j.createdAt DESC")
+	Page<Long> findIdsByMemberIdInAndIdNotInOrderByCreatedAtDesc(@Param("memberIds") List<Long> memberIds, @Param("excludeJournalIds") List<Long> excludeJournalIds, Pageable pageable);
+
+	@Query(value = "SELECT j.id FROM journal j WHERE j.member_id NOT IN (:memberIds) AND j.id NOT IN (:excludeJournalIds) ORDER BY RAND() LIMIT :limit", nativeQuery = true)
+	List<Long> findRandomIdsByMemberIdNotInAndIdNotIn(
+		@Param("memberIds") List<Long> memberIds,
+		@Param("excludeJournalIds") List<Long> excludeJournalIds,
+		@Param("limit") int limit
+	);
 }

--- a/src/main/java/com/traveljournal/domain/member/entity/Member.java
+++ b/src/main/java/com/traveljournal/domain/member/entity/Member.java
@@ -72,8 +72,9 @@ public class Member {
 	}
 
 	@Builder
-	public Member(String providerId, String nickname, String profileImageUrl,
+	public Member(Long id, String providerId, String nickname, String profileImageUrl,
 		AccountScope accountScope, SocialProvider socialProvider) {
+		this.id = id;
 		this.providerId = providerId;
 		this.nickname = nickname;
 		this.profileImageUrl = profileImageUrl;

--- a/src/main/java/com/traveljournal/domain/member/repository/FollowRepository.java
+++ b/src/main/java/com/traveljournal/domain/member/repository/FollowRepository.java
@@ -1,14 +1,17 @@
 package com.traveljournal.domain.member.repository;
 
-import com.traveljournal.domain.member.entity.Follow;
-import com.traveljournal.domain.member.entity.Member;
-import com.traveljournal.domain.member.entity.RequestStatus;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-import java.util.Optional;
+import com.traveljournal.domain.member.entity.Follow;
+import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.entity.RequestStatus;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     // 내가 팔로우 하는 사람들
@@ -23,4 +26,10 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     Page<Follow> findAllByToMemberIdAndRequestStatus(Long toMemberId, RequestStatus requestStatus, Pageable pageable);
     Optional<Follow> findByIdAndToMemberId(Long followId, Long toMemberId);
     Optional<Follow> findByFromMemberIdAndToMemberIdAndRequestStatus(Long fromMemberId, Long toMemberId, RequestStatus requestStatus);
+
+    @Query("SELECT f.fromMember.id FROM Follow f WHERE f.toMember.id = :followerId")
+    List<Long> findFollowedIdsByFollowerId(@Param("followerId") Long followerId);
+
+    @Query("SELECT f.toMember.id FROM Follow f WHERE f.fromMember.id = :memberId AND f.requestStatus = 'ACCEPTED'")
+    List<Long> findAcceptedToMemberIdsByFromMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/traveljournal/domain/member/service/FollowService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/FollowService.java
@@ -1,5 +1,12 @@
 package com.traveljournal.domain.member.service;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.traveljournal.domain.member.dto.FollowProfileResponse;
 import com.traveljournal.domain.member.dto.FollowRequestResponse;
 import com.traveljournal.domain.member.entity.Follow;
@@ -9,11 +16,8 @@ import com.traveljournal.domain.member.repository.FollowRepository;
 import com.traveljournal.global.exception.FollowAccountScopeException;
 import com.traveljournal.global.exception.FollowBadRequestException;
 import com.traveljournal.global.exception.FollowNotFoundException;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -117,5 +121,10 @@ public class FollowService {
     public Page<FollowRequestResponse> findFollowRequests(Long memberId, Pageable pageable) {
         return followRepository.findAllByToMemberIdAndRequestStatus(memberId, RequestStatus.REQUESTED, pageable)
                 .map(FollowRequestResponse::of);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> getFollowingMemberIds(Long followerId) {
+        return followRepository.findFollowedIdsByFollowerId(followerId);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/traveljournal_db
+    url: jdbc:mysql://localhost:3306/traveljournal_db?rewriteBatchedStatements=true&serverTimezone=Asia/Seoul
     username: root
     password: ${secret.dev-password}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://${secret.prod-db-endpoint}:3306/traveljournal_db?serverTimezone=Asia/Seoul
+    url: jdbc:mysql://${secret.prod-db-endpoint}:3306/traveljournal_db?rewriteBatchedStatements=true&serverTimezone=Asia/Seoul
     username: root
     password: ${secret.prod-password}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,9 @@ spring:
       hibernate:
         jdbc:
           time_zone: Asia/Seoul
+          batch_size: 100
+        order_updates: true
+        order_insert: true
   servlet:
     multipart:
       max-file-size: 5MB # 한개 파일의 최대 사이즈 (default: 1MB)


### PR DESCRIPTION
## 🔥 해결된 이슈
- Closes #41 
- JIRA # TJFE-173
## 📌 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련된 테스트를 추가하거나 기존 테스트를 실행하여 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드를 따랐는지 확인했습니다.
- [x] 배포가 필요한 경우 관련 작업을 완료했습니다. (예: CI/CD 설정, 환경 변수 추가 등)

## ✨ 작업 내용
- 탐험하기 - 여행일지
> 팔로우한 회원이 존재하고, 팔로우한 회원이 올린 게시물을 읽지 않았다면 최근에 올린 게시글 위주로 보여줍니다.
팔로우한 회원이 존재하지만 게시글을 모두 읽었거나 팔로우한 회원의 게시글이 없다면 비팔로우 회원의 게시글을 랜덤하게 보여줍니다.
팔로우한 회원이 없으면 비팔로우 회원의 게시글을 랜덤하게 보여줍니다.
본인꺼는 탐험하기에서 보이지 않습니다.

- 탐험하기 - 읽은 게시물 체크
> 게시물 읽었을 경우 프론트 -> 서버로 해당 journal_id 여러개를 넘겨주시면 됩니다.
1개 읽었을때마다 넘겨주시면 서버 트래픽이 과부하가 걸리기때문에 List형태로 구현되었습니다.
탐험하기 API를 새로고침을 했을때 같은 경우 읽었다는 것을 서버에 알려주시면 됩니다.

- 탐험하기 - 읽은 게시물 3일 후 삭제
> 매일 새벽 3시에 자동으로 데이터베이스를 확인하여 읽은 내역의 시간이 3일이 지났다면 읽은 내역을 삭제합니다.
읽은 내역에서 삭제될 경우 해당 게시물이 다시 보이게 됩니다.
현재 탐험하기 - 여행일지의 좋아요와 댓글 수는 숫자만 들어가있는 더미입니다.
현재 따로 좋아요와 댓글 기능이 존재하지 않습니다.

## 🚀 추가 설명
> 금주 수요일 회의에서 탐험하기 플레이스는 진행하지 않도록 되었습니다.

## 📸 테스트 결과 (스크린샷 혹은 로그)
> [스크린샷 혹은 테스트 정상 확인 로그를 첨부해주세요.]
![image](https://github.com/user-attachments/assets/05290c60-84cc-48b9-b251-4f10be78c0db)
![image](https://github.com/user-attachments/assets/f83e8f30-59e5-463a-83e8-b78e1b878973)
![image](https://github.com/user-attachments/assets/5bd1d6cc-9dac-4348-b107-67031d6f07d5)
