### PR TITLE
[Feature] 회원 차단 기능

### DIFF
--- a/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
@@ -45,4 +45,14 @@ public interface JournalRepository extends JpaRepository<Journal, Long> {
 		@Param("excludeJournalIds") List<Long> excludeJournalIds,
 		@Param("limit") int limit
 	);
+
+	@Query("""
+    SELECT DISTINCT j.id
+    FROM Journal j
+    LEFT JOIN j.hashTags h
+    WHERE (j.title LIKE %:keyword%
+       OR j.region LIKE %:keyword%
+       OR h.tagName LIKE %:keyword%) AND j.member.id NOT IN :blockedMemberIds
+    """)
+	Page<Long> findIdsByKeywordExcludingBlockedMembers(@Param("keyword") String keyword, @Param("blockedMemberIds") List<Long> blockedMemberIds, Pageable pageable);
 }

--- a/src/main/java/com/traveljournal/domain/member/controller/BlockController.java
+++ b/src/main/java/com/traveljournal/domain/member/controller/BlockController.java
@@ -1,0 +1,57 @@
+package com.traveljournal.domain.member.controller;
+
+import com.traveljournal.domain.member.dto.BlockResponse;
+import com.traveljournal.domain.member.service.BlockService;
+import com.traveljournal.domain.member.service.MemberService;
+import com.traveljournal.global.data.ApiResponseHandler;
+import com.traveljournal.global.security.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/block")
+public class BlockController {
+    private final BlockService blockService;
+    private final MemberService memberService;
+
+    @Operation(
+            summary = "회원 차단",
+            description = "현재 로그인한 사용자가 특정 사용자를 차단합니다.",
+            security = @SecurityRequirement(name = "bearer-key")
+    )
+    @PostMapping("/{blockedId}")
+    public ResponseEntity<?> blockMember(@PathVariable Long blockedId) {
+        Long currentMemberId = SecurityUtil.getCurrentMemberId();
+        blockService.blockMember(currentMemberId, blockedId);
+        return ApiResponseHandler.onSuccess("차단 성공");
+    }
+
+    @Operation(
+            summary = "회원 차단 해제",
+            description = "현재 로그인한 사용자가 차단한 회원을 차단 해제합니다. ",
+            security = @SecurityRequirement(name = "bearer-key")
+    )
+    @DeleteMapping("/{blockedId}")
+    public ResponseEntity<?> unblockMember(@PathVariable Long blockedId) {
+        Long currentMemberId = SecurityUtil.getCurrentMemberId();
+        blockService.unblockMember(currentMemberId, blockedId);
+        return ApiResponseHandler.onSuccess("차단 해제 성공");
+    }
+
+    @Operation(
+            summary = "차단한 회원 목록 조회",
+            description = "현재 로그인한 회원이 차단한 회원 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "bearer-key")
+    )
+    @GetMapping("/list")
+    public ResponseEntity<Page<BlockResponse>> getBlockedMembers(Pageable pageable) {
+        Long currentMemberId = SecurityUtil.getCurrentMemberId();
+        return ApiResponseHandler.getObjectSuccess(blockService.getBlockedMembers(currentMemberId, pageable));
+    }
+}

--- a/src/main/java/com/traveljournal/domain/member/dto/BlockResponse.java
+++ b/src/main/java/com/traveljournal/domain/member/dto/BlockResponse.java
@@ -1,0 +1,19 @@
+package com.traveljournal.domain.member.dto;
+
+import com.traveljournal.domain.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record BlockResponse(
+        Long memberId,
+        String nickname,
+        String profileImageUrl
+) {
+    public static BlockResponse of(Member blocked) {
+        return BlockResponse.builder()
+                .memberId(blocked.getId())
+                .nickname(blocked.getNickname())
+                .profileImageUrl(blocked.getProfileImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/traveljournal/domain/member/entity/Block.java
+++ b/src/main/java/com/traveljournal/domain/member/entity/Block.java
@@ -1,0 +1,28 @@
+package com.traveljournal.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Block {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "block_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocker_id", nullable = false)
+    private Member blocker;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocked_id", nullable = false)
+    private Member blocked;
+
+}

--- a/src/main/java/com/traveljournal/domain/member/repository/BlockRepository.java
+++ b/src/main/java/com/traveljournal/domain/member/repository/BlockRepository.java
@@ -1,0 +1,17 @@
+package com.traveljournal.domain.member.repository;
+
+import com.traveljournal.domain.member.entity.Block;
+import com.traveljournal.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BlockRepository extends JpaRepository<Block, Long> {
+    boolean existsByBlockerAndBlocked(Member blocker, Member blocked);
+    Optional<Block> findByBlockerAndBlocked(Member blocker, Member blocked);
+    Page<Block> findAllByBlocker(Member blocker, Pageable pageable);
+    void deleteByBlockerAndBlocked(Member blocker, Member blocked);
+}

--- a/src/main/java/com/traveljournal/domain/member/repository/BlockRepository.java
+++ b/src/main/java/com/traveljournal/domain/member/repository/BlockRepository.java
@@ -5,6 +5,8 @@ import com.traveljournal.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,4 +16,7 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
     Optional<Block> findByBlockerAndBlocked(Member blocker, Member blocked);
     Page<Block> findAllByBlocker(Member blocker, Pageable pageable);
     void deleteByBlockerAndBlocked(Member blocker, Member blocked);
+
+    @Query("SELECT b.blocked.id FROM Block b WHERE b.blocker = :blocker")
+    List<Long> findBlockedMemberIdsByBlocker(@Param("blocker") Member blocker);
 }

--- a/src/main/java/com/traveljournal/domain/member/repository/BlockRepository.java
+++ b/src/main/java/com/traveljournal/domain/member/repository/BlockRepository.java
@@ -17,6 +17,6 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
     Page<Block> findAllByBlocker(Member blocker, Pageable pageable);
     void deleteByBlockerAndBlocked(Member blocker, Member blocked);
 
-    @Query("SELECT b.blocked.id FROM Block b WHERE b.blocker = :blocker")
-    List<Long> findBlockedMemberIdsByBlocker(@Param("blocker") Member blocker);
+    @Query("SELECT b.blocked.id FROM Block b WHERE b.blocker.id = :blockerId")
+    List<Long> findBlockedMemberIdsByBlockerId(@Param("blockerId") Long blockerId);
 }

--- a/src/main/java/com/traveljournal/domain/member/service/BlockService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/BlockService.java
@@ -28,7 +28,7 @@ public class BlockService {
         Member blocked = findMemberById(blockedId);
 
         if (blockRepository.existsByBlockerAndBlocked(blocker, blocked)) {
-            throw new BlockBadRequestException("이미 차단한 사용자입니다,");
+            throw new BlockBadRequestException("이미 차단한 사용자입니다.");
         }
 
         Block block = Block.builder()

--- a/src/main/java/com/traveljournal/domain/member/service/BlockService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/BlockService.java
@@ -1,0 +1,64 @@
+package com.traveljournal.domain.member.service;
+
+import com.traveljournal.domain.member.dto.BlockResponse;
+import com.traveljournal.domain.member.entity.Block;
+import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.repository.BlockRepository;
+import com.traveljournal.global.exception.BlockBadRequestException;
+import com.traveljournal.global.exception.FollowBadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BlockService {
+    private final BlockRepository blockRepository;
+    private final MemberService memberService;
+    private Member findMemberById(Long id) {return memberService.findById(id);}
+    @Transactional
+    public void blockMember(Long blockerId, Long blockedId) {
+
+        Member blocker = findMemberById(blockerId);
+        Member blocked = findMemberById(blockedId);
+
+        if (blockRepository.existsByBlockerAndBlocked(blocker, blocked)) {
+            throw new BlockBadRequestException("이미 차단한 사용자입니다,");
+        }
+
+        Block block = Block.builder()
+                .blocker(blocker)
+                .blocked(blocked)
+                .build();
+
+        blockRepository.save(block);
+    }
+
+    public void unblockMember(Long blockerId, Long blockedId) {
+        Member blocker = findMemberById(blockerId);
+        Member blocked = findMemberById(blockedId);
+
+        Block block = blockRepository.findByBlockerAndBlocked(blocker, blocked)
+                .orElseThrow(()-> new BlockBadRequestException("차단 내역이 없습니다."));
+
+        blockRepository.delete(block);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<BlockResponse> getBlockedMembers(Long blockerId, Pageable pageable) {
+        Member blocker = findMemberById(blockerId);
+        return blockRepository.findAllByBlocker(blocker, pageable)
+                .map(block -> BlockResponse.of(block.getBlocked()));
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isBlocked(Member viewer, Member target) {
+        return blockRepository.existsByBlockerAndBlocked(viewer, target) ||
+                blockRepository.existsByBlockerAndBlocked(target, viewer);
+    }
+}

--- a/src/main/java/com/traveljournal/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/traveljournal/domain/place/repository/PlaceRepository.java
@@ -27,5 +27,9 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 	@Query("SELECT p.id FROM Place p WHERE p.member.id = :memberId")
 	Page<Long> findIdsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 
-
+	@Query("""
+		SELECT p.id
+		FROM Place p
+		WHERE (p.title LIKE %:keyword% OR p.region LIKE %:keyword%) AND p.member.id NOT IN :blockedMemberIds""")
+	Page<Long> findIdsByKeywordExcludingBlockedMembers(@Param("keyword") String keyword,@Param("blockedMemberIds") List<Long> blockedMemberIds, Pageable pageable);
 }

--- a/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
+++ b/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
@@ -64,7 +64,7 @@ public class SearchController {
 		@RequestParam String keyword,
 		@ParameterObject @PageableDefault Pageable pageable) {
 
-		Page<PlaceListResponse> result = placeSearchService.searchPlaces(keyword, pageable);
+		Page<PlaceListResponse> result = placeSearchService.searchPlacesByBlockedMembers(keyword, pageable);
 
 		return ApiResponseHandler.getObjectSuccess(result);
 	}
@@ -80,7 +80,7 @@ public class SearchController {
 		@RequestParam String keyword,
 		@ParameterObject @PageableDefault Pageable pageable) {
 
-		Page<JournalListResponse> result = journalSearchService.searchJournals(keyword, pageable);
+		Page<JournalListResponse> result = journalSearchService.searchJournalsByBlockedMembers(keyword, pageable);
 
 		return ApiResponseHandler.getObjectSuccess(result);
 	}

--- a/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
+++ b/src/main/java/com/traveljournal/domain/search/controller/SearchController.java
@@ -1,5 +1,6 @@
 package com.traveljournal.domain.search.controller;
 
+import com.traveljournal.global.security.util.SecurityUtil;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -45,14 +46,9 @@ public class SearchController {
 	public ResponseEntity<Page<MemberSearchResponse>> searchMembers(
 		@RequestParam @NotBlank(message = "검색어는 비어 있을 수 없습니다.") String keyword,
 		@PageableDefault(sort = "nickname") Pageable pageable) {
-/*
-        // 키워드가 비어 있을 경우, 409 상태 코드로 실패 메시지 반환
-        if (keyword == null || keyword.isEmpty()) {
-            return ApiResponseHandler.onFailure("검색어는 비어 있을 수 없습니다.");
-        }
 
- */
-		Page<MemberSearchResponse> result = memberSearchService.searchMembers(keyword, pageable);
+		Long currentMemberId = SecurityUtil.getCurrentMemberId();
+		Page<MemberSearchResponse> result = memberSearchService.searchByNickname(keyword, pageable, currentMemberId);
 
 		return ApiResponseHandler.getObjectSuccess(result);
 	}

--- a/src/main/java/com/traveljournal/domain/search/repository/MemberSearchRepository.java
+++ b/src/main/java/com/traveljournal/domain/search/repository/MemberSearchRepository.java
@@ -4,9 +4,20 @@ import com.traveljournal.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MemberSearchRepository extends JpaRepository<Member, Long> {
     Page<Member> findByNicknameContaining(String nickname, Pageable pageable);
+    @Query("""
+        SELECT m FROM Member m
+        WHERE m.nickname LIKE %:nickname%
+        AND m.id <> :currentMemberId
+        AND m.id NOT IN (
+            SELECT b.blocked.id FROM Block b WHERE b.blocker.id = :currentMemberId
+        )
+    """)
+    Page<Member> findByNicknameContainingAndIdNotIn(@Param("nickname") String nickname, @Param("currentMemberId") Long currentMemberId, Pageable pageable);
 }

--- a/src/main/java/com/traveljournal/domain/search/service/JournalSearchService.java
+++ b/src/main/java/com/traveljournal/domain/search/service/JournalSearchService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.traveljournal.domain.member.repository.BlockRepository;
+import com.traveljournal.global.security.util.SecurityUtil;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JournalSearchService {
 	private final JournalRepository journalRepository;
+	private final BlockRepository blockRepository;
 
 	@Transactional(readOnly = true)
 	public Page<JournalListResponse> searchJournals(String keyword, Pageable pageable) {
@@ -48,6 +51,40 @@ public class JournalSearchService {
 					journal.getEndDate()
 				))
 				.toList(),
+			pageable,
+			journalIdPage.getTotalElements()
+		);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<JournalListResponse> searchJournalsByBlockedMembers(String keyword, Pageable pageable) {
+
+		Long currentMemberId = SecurityUtil.getCurrentMemberId();
+		List<Long> blockedIds = blockRepository.findBlockedMemberIdsByBlockerId(currentMemberId);
+
+		Page<Long> journalIdPage = journalRepository.findIdsByKeywordExcludingBlockedMembers(keyword, blockedIds, pageable);
+		List<Long> journalIds = journalIdPage.getContent();
+		List<Journal> journals = journalRepository.findAllByIdInFetchJoin(journalIds);
+
+		Map<Long, Journal> journalMap = journals.stream()
+				.collect(Collectors.toMap(Journal::getId, j -> j));
+		List<Journal> sortedJournals = journalIds.stream()
+				.map(journalMap::get)
+				.toList();
+
+
+		return new PageImpl<>(
+			sortedJournals.stream()
+					.map(journal -> new JournalListResponse(
+							journal.getId(),
+							journal.getHashTags().stream().map(HashTag::getTagName).toList(),
+							journal.getTitle(),
+							journal.getNights(),
+							journal.getDays(),
+							journal.getStartDate(),
+							journal.getEndDate()
+					))
+					.toList(),
 			pageable,
 			journalIdPage.getTotalElements()
 		);

--- a/src/main/java/com/traveljournal/domain/search/service/MemberSearchService.java
+++ b/src/main/java/com/traveljournal/domain/search/service/MemberSearchService.java
@@ -2,6 +2,7 @@ package com.traveljournal.domain.search.service;
 
 import com.traveljournal.domain.member.dto.MemberProfileResponse;
 import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.repository.BlockRepository;
 import com.traveljournal.domain.search.dto.MemberSearchResponse;
 import com.traveljournal.domain.search.repository.MemberSearchRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import java.util.List;
 public class MemberSearchService {
 
     private final MemberSearchRepository memberSearchRepository;
+    private final BlockRepository blockRepository;
 
     @Transactional(readOnly = true)
     public Page<MemberSearchResponse> searchMembers(String keyword, Pageable pageable) {
@@ -30,4 +32,17 @@ public class MemberSearchService {
                 )
         );
     }
+
+    @Transactional(readOnly = true)
+    public Page<MemberSearchResponse> searchByNickname(String keyword, Pageable pageable, Long currentMemberId) {
+
+        // currentMemberId를 넘겨서 repository 쿼리에서 차단 회원 자동 제외
+        Page<Member> members = memberSearchRepository.findByNicknameContainingAndIdNotIn(keyword, currentMemberId, pageable);
+
+        return members.map(member -> {
+            MemberProfileResponse profile = MemberProfileResponse.of(member);
+            return MemberSearchResponse.of(member.getId(), profile);
+        });
+    }
+
 }

--- a/src/main/java/com/traveljournal/domain/search/service/PlaceSearchService.java
+++ b/src/main/java/com/traveljournal/domain/search/service/PlaceSearchService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.traveljournal.domain.member.repository.BlockRepository;
+import com.traveljournal.global.security.util.SecurityUtil;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class PlaceSearchService {
 
 	private final PlaceRepository placeRepository;
+	private final BlockRepository blockRepository;
 
 	@Transactional(readOnly = true)
 	public Page<PlaceListResponse> searchPlaces(String keyword, Pageable pageable) {
@@ -45,6 +48,36 @@ public class PlaceSearchService {
 				.toList(),
 			pageable,
 			placeIdPage.getTotalElements()
+		);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<PlaceListResponse> searchPlacesByBlockedMembers(String keyword, Pageable pageable) {
+
+		Long currentMemberId = SecurityUtil.getCurrentMemberId();
+		List<Long> blockedIds = blockRepository.findBlockedMemberIdsByBlockerId(currentMemberId);
+
+		Page<Long> placeIdPage = placeRepository.findIdsByKeywordExcludingBlockedMembers(keyword, blockedIds, pageable);
+		List<Long> placeIds = placeIdPage.getContent();
+		List<Place> places = placeRepository.findAllByIdIn(placeIds);
+
+		Map<Long, Place> placeMap = places.stream()
+				.collect(Collectors.toMap(Place::getId, p -> p));
+		List<Place> sortedPlaces = placeIds.stream()
+				.map(placeMap::get)
+				.toList();
+
+		return new PageImpl<>(
+				sortedPlaces.stream()
+						.map(place -> new PlaceListResponse(
+								place.getId(),
+								place.getTitle(),
+								place.getRegion(),
+								place.getThumbnailUrl()
+						))
+						.toList(),
+				pageable,
+				placeIdPage.getTotalElements()
 		);
 	}
 }

--- a/src/main/java/com/traveljournal/global/exception/BlockBadRequestException.java
+++ b/src/main/java/com/traveljournal/global/exception/BlockBadRequestException.java
@@ -1,0 +1,7 @@
+package com.traveljournal.global.exception;
+
+public class BlockBadRequestException extends RuntimeException{
+    public BlockBadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/traveljournal/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/traveljournal/global/exception/GlobalExceptionHandler.java
@@ -47,4 +47,9 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<String> handeFollowAccountScope(FollowAccountScopeException ex) {
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ex.getMessage());
 	}
+
+	@ExceptionHandler(BlockBadRequestException.class)
+	public ResponseEntity<String> handleBlockBadRequest(BlockBadRequestException ex) {
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+	}
 }


### PR DESCRIPTION
## 🔥 해결된 이슈
- Closes #45 

## 📌 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련된 테스트를 추가하거나 기존 테스트를 실행하여 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드를 따랐는지 확인했습니다.
- [x] 배포가 필요한 경우 관련 작업을 완료했습니다. (예: CI/CD 설정, 환경 변수 추가 등)

## ✨ 작업 내용
- **회원 차단 기능 구현**
> 로그인한 사용자가 특정 회원을 차단하는 기능 
> 차단한 회원 목록 조회
- **차단 기능 반영 검색 필터링**
> 회원 검색, 장소 검색 ,여행일지 검색 시 차단한 회원의 콘텐츠가 노출되지 않도록 필터링 로직 추가
> 각 검색 API 에 로그인한 사용자의 차단 리스트를 조회해 제외 처리 적용
> 필터링 기준 : 로그인한 사용자가 차단한 사용자들의 콘텐츠를 제외하는 방식


## 🚀 추가 설명
> 화철님이 작성해두신 기존 search 관련 query 문을 그대로 활용하면서, 차단한 사용자 ID 목록(blockedMemberIds)을 추가 파라미터로 전달하여 결과를 필터링했습니다.
차단 리스트를 조회 후, 차단된 회원의 콘텐츠는 노출하지 않도록 기존 쿼리에 NOT IN 조건을 추가하는 형태로 확장했습니다.

>MemberSearch: Long 타입 사용 : 단일 회원 ID 기준으로 단건 또는 단순 필터링 위주
PlaceSearch / JournalSearch: List<Long> 타입 사용 : 다수의 결과를 반환하고 연관 데이터를 한번에 가져오기 위해 List<Long>로 ID를 먼저 조회 후 데이터 조회

## 📸 테스트 결과 (스크린샷 혹은 로그)
> 차단 성공
![차단 성공](https://github.com/user-attachments/assets/985db669-663d-411a-b989-01a7f2db1d71)

> 차단 목록
![차단 목록](https://github.com/user-attachments/assets/75a1dbaa-852d-460f-8865-31cbe31fb965)

> 차단 후 MemberSearch
![검색 목록](https://github.com/user-attachments/assets/e214350f-3682-4639-adf6-e7b9e5da3715)

> 차단 후 PlacesSearch
![places](https://github.com/user-attachments/assets/f7260b09-d84a-4795-8465-6f0b7a1e7040)

> 차단 후 JournalsSearch
![journal](https://github.com/user-attachments/assets/7e9e3a59-315b-4a0b-8b02-5a7707692a33)
