### PR TITLE
[Feature] 메타데이터 추출 API 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ dependencies {
 
     // 이미지 리사이징을 위한 Thumbnailator
     implementation 'net.coobird:thumbnailator:0.4.20'
+    implementation 'com.drewnoakes:metadata-extractor:2.18.0'
 }
 
 // 현대적인 태스크 구성 방식

--- a/src/main/java/com/traveljournal/domain/kakaoMap/port/GeoAddressLookupPort.java
+++ b/src/main/java/com/traveljournal/domain/kakaoMap/port/GeoAddressLookupPort.java
@@ -1,0 +1,5 @@
+package com.traveljournal.domain.kakaoMap.port;
+
+public interface GeoAddressLookupPort {
+	String getAddress(double latitude, double longitude);
+}

--- a/src/main/java/com/traveljournal/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/traveljournal/domain/photo/controller/PhotoController.java
@@ -1,0 +1,31 @@
+package com.traveljournal.domain.photo.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.traveljournal.domain.photo.dto.PhotoMetadataResponse;
+import com.traveljournal.domain.photo.service.PhotoMetadataService;
+import com.traveljournal.global.data.ApiResponseHandler;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/photo")
+@Tag(name = "Photo API", description = "사진 기능 API")
+public class PhotoController {
+
+	private final PhotoMetadataService photoMetadataService;
+
+	@PostMapping("/metadata")
+	public ResponseEntity<PhotoMetadataResponse> extractMetadata(
+		@RequestParam("image") MultipartFile imageFile) {
+
+		return ApiResponseHandler.getObjectSuccess(photoMetadataService.extractMetadata(imageFile));
+	}
+}

--- a/src/main/java/com/traveljournal/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/traveljournal/domain/photo/controller/PhotoController.java
@@ -1,9 +1,10 @@
 package com.traveljournal.domain.photo.controller;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -11,6 +12,9 @@ import com.traveljournal.domain.photo.dto.PhotoMetadataResponse;
 import com.traveljournal.domain.photo.service.PhotoMetadataService;
 import com.traveljournal.global.data.ApiResponseHandler;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -22,9 +26,19 @@ public class PhotoController {
 
 	private final PhotoMetadataService photoMetadataService;
 
-	@PostMapping("/metadata")
+	@PostMapping(value = "/metadata",
+		consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Operation(
+		summary = "사진 메타데이터 추출",
+		description = "업로드한 사진 파일에서 촬영일시, 주소, 위도, 경도 등 메타데이터를 추출합니다.",
+		security = @SecurityRequirement(name = "bearer-key")
+	)
 	public ResponseEntity<PhotoMetadataResponse> extractMetadata(
-		@RequestParam("image") MultipartFile imageFile) {
+		@Parameter(
+			description = "메타데이터를 추출할 이미지 파일",
+			required = true
+		)
+		@RequestPart("image") MultipartFile imageFile) {
 
 		return ApiResponseHandler.getObjectSuccess(photoMetadataService.extractMetadata(imageFile));
 	}

--- a/src/main/java/com/traveljournal/domain/photo/dto/PhotoMetadataResponse.java
+++ b/src/main/java/com/traveljournal/domain/photo/dto/PhotoMetadataResponse.java
@@ -1,0 +1,25 @@
+package com.traveljournal.domain.photo.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PhotoMetadataResponse(
+	String takenDateTime,    // 촬영일시
+	String address,          // 주소
+	Double latitude,         // 위도
+	Double longitude         // 경도
+) {
+	public static PhotoMetadataResponse of(
+		String takenDateTime, String address, Double latitude, Double longitude) {
+		return PhotoMetadataResponse.builder()
+			.takenDateTime(takenDateTime)
+			.address(address)
+			.latitude(latitude)
+			.longitude(longitude)
+			.build();
+	}
+
+	public static PhotoMetadataResponse empty() {
+		return PhotoMetadataResponse.builder().build();
+	}
+}

--- a/src/main/java/com/traveljournal/domain/photo/dto/PhotoMetadataResponse.java
+++ b/src/main/java/com/traveljournal/domain/photo/dto/PhotoMetadataResponse.java
@@ -1,12 +1,17 @@
 package com.traveljournal.domain.photo.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record PhotoMetadataResponse(
+	@Schema(example = "2025-06-04T21:27:32")
 	String takenDateTime,    // 촬영일시
+	@Schema(example = "서울 강서구 마곡동 735")
 	String address,          // 주소
+	@Schema(example = "37.568875000000006")
 	Double latitude,         // 위도
+	@Schema(example = "126.82173888888889")
 	Double longitude         // 경도
 ) {
 	public static PhotoMetadataResponse of(

--- a/src/main/java/com/traveljournal/domain/photo/dto/PhotoMetadataResponse.java
+++ b/src/main/java/com/traveljournal/domain/photo/dto/PhotoMetadataResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record PhotoMetadataResponse(
-	@Schema(example = "2025-06-04T21:27:32")
+	@Schema(example = "2025.06.04 21:27")
 	String takenDateTime,    // 촬영일시
 	@Schema(example = "서울 강서구 마곡동 735")
 	String address,          // 주소

--- a/src/main/java/com/traveljournal/domain/photo/service/PhotoMetadataService.java
+++ b/src/main/java/com/traveljournal/domain/photo/service/PhotoMetadataService.java
@@ -51,8 +51,12 @@ public class PhotoMetadataService {
 				if (dateString != null) {
 					DateTimeFormatter exifFormatter = DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss");
 					LocalDateTime localDateTime = LocalDateTime.parse(dateString, exifFormatter);
-					return localDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+
+					DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+					return localDateTime.format(outputFormatter);
 				}
+
+
 			} catch (Exception e) {
 				log.debug("촬영일시 추출 실패(메타데이터 없음 또는 파싱 실패): {}", e.getMessage());
 			}

--- a/src/main/java/com/traveljournal/domain/photo/service/PhotoMetadataService.java
+++ b/src/main/java/com/traveljournal/domain/photo/service/PhotoMetadataService.java
@@ -1,6 +1,7 @@
 package com.traveljournal.domain.photo.service;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 import org.springframework.stereotype.Service;
@@ -44,19 +45,21 @@ public class PhotoMetadataService {
 
 	private String extractDateTime(Metadata metadata) {
 		ExifSubIFDDirectory directory = metadata.getFirstDirectoryOfType(ExifSubIFDDirectory.class);
-		if (directory != null && directory.hasTagName(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL)) {
+		if (directory != null && directory.containsTag(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL)) {
 			try {
-				return directory.getDate(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL)
-					.toInstant()
-					.atZone(java.time.ZoneId.systemDefault())
-					.toLocalDateTime()
-					.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+				String dateString = directory.getString(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL);
+				if (dateString != null) {
+					DateTimeFormatter exifFormatter = DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss");
+					LocalDateTime localDateTime = LocalDateTime.parse(dateString, exifFormatter);
+					return localDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+				}
 			} catch (Exception e) {
 				log.debug("촬영일시 추출 실패(메타데이터 없음 또는 파싱 실패): {}", e.getMessage());
 			}
 		}
 		return null;
 	}
+
 
 	private String extractAddress(Double latitude, Double longitude) {
 		if (latitude != null && longitude != null) {

--- a/src/main/java/com/traveljournal/domain/photo/service/PhotoMetadataService.java
+++ b/src/main/java/com/traveljournal/domain/photo/service/PhotoMetadataService.java
@@ -1,0 +1,91 @@
+package com.traveljournal.domain.photo.service;
+
+import java.io.IOException;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.imaging.ImageProcessingException;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.exif.ExifSubIFDDirectory;
+import com.drew.metadata.exif.GpsDirectory;
+import com.traveljournal.domain.kakaoMap.port.GeoAddressLookupPort;
+import com.traveljournal.domain.photo.dto.PhotoMetadataResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PhotoMetadataService {
+
+	private final GeoAddressLookupPort geoAddressLookupPort;
+
+	public PhotoMetadataResponse extractMetadata(MultipartFile imageFile) {
+		try {
+			Metadata metadata = ImageMetadataReader.readMetadata(imageFile.getInputStream());
+
+			Double latitude = extractLatitude(metadata);
+			Double longitude = extractLongitude(metadata);
+			return PhotoMetadataResponse.of(
+				extractDateTime(metadata),
+				extractAddress(latitude,longitude),
+				latitude,
+				longitude
+			);
+
+		} catch (ImageProcessingException | IOException e) {
+			return PhotoMetadataResponse.empty();
+		}
+	}
+
+	private String extractDateTime(Metadata metadata) {
+		ExifSubIFDDirectory directory = metadata.getFirstDirectoryOfType(ExifSubIFDDirectory.class);
+		if (directory != null && directory.hasTagName(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL)) {
+			try {
+				return directory.getDate(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL)
+					.toInstant()
+					.atZone(java.time.ZoneId.systemDefault())
+					.toLocalDateTime()
+					.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+			} catch (Exception e) {
+				log.debug("촬영일시 추출 실패(메타데이터 없음 또는 파싱 실패): {}", e.getMessage());
+			}
+		}
+		return null;
+	}
+
+	private String extractAddress(Double latitude, Double longitude) {
+		if (latitude != null && longitude != null) {
+			return geoAddressLookupPort.getAddress(latitude, longitude);
+		}
+		return null;
+	}
+
+	private Double extractLatitude(Metadata metadata) {
+		GpsDirectory gpsDirectory = metadata.getFirstDirectoryOfType(GpsDirectory.class);
+		if (gpsDirectory != null && gpsDirectory.hasTagName(GpsDirectory.TAG_LATITUDE)) {
+			try {
+				return gpsDirectory.getGeoLocation().getLatitude();
+			} catch (Exception e) {
+				log.debug("위도 추출 실패: {}", e.getMessage());
+			}
+		}
+		return null;
+	}
+
+	private Double extractLongitude(Metadata metadata) {
+		GpsDirectory gpsDirectory = metadata.getFirstDirectoryOfType(GpsDirectory.class);
+		if (gpsDirectory != null && gpsDirectory.hasTagName(GpsDirectory.TAG_LONGITUDE)) {
+			try {
+				return gpsDirectory.getGeoLocation().getLongitude();
+			} catch (Exception e) {
+				log.debug("경도 추출 실패: {}", e.getMessage());
+			}
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/traveljournal/infra/kakaoMap/dto/KakaoMapResponse.java
+++ b/src/main/java/com/traveljournal/infra/kakaoMap/dto/KakaoMapResponse.java
@@ -1,0 +1,44 @@
+package com.traveljournal.infra.kakaoMap.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoMapResponse {
+	private Meta meta;
+	private List<Document> documents;
+
+	@Getter
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Meta {
+		@JsonProperty("total_count")
+		private int totalCount;
+	}
+
+	@Getter
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Document {
+		private Address address;
+		@JsonProperty("road_address")
+		private RoadAddress roadAddress;
+	}
+
+	@Getter
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Address {
+		@JsonProperty("address_name")
+		private String addressName;
+	}
+
+	@Getter
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class RoadAddress {
+		@JsonProperty("address_name")
+		private String addressName;
+	}
+}

--- a/src/main/java/com/traveljournal/infra/kakaoMap/service/KakaoMapService.java
+++ b/src/main/java/com/traveljournal/infra/kakaoMap/service/KakaoMapService.java
@@ -1,0 +1,37 @@
+package com.traveljournal.infra.kakaoMap.service;
+
+import org.springframework.stereotype.Service;
+
+import com.traveljournal.domain.kakaoMap.port.GeoAddressLookupPort;
+import com.traveljournal.global.config.KakaoOAuthConfig;
+import com.traveljournal.global.exception.ExternalApiException;
+import com.traveljournal.infra.kakaoMap.dto.KakaoMapResponse;
+import com.traveljournal.infra.kakaoMap.util.KakaoMapFeignClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoMapService implements GeoAddressLookupPort {
+	private final KakaoMapFeignClient kakaoMapFeignClient;
+	private final KakaoOAuthConfig kakaoOAuthConfig;
+
+	public String getAddress(double latitude, double longitude) {
+		try {
+			String authorization = "KakaoAK " + kakaoOAuthConfig.getAdminKey();
+			KakaoMapResponse kakaoMapResponse = kakaoMapFeignClient.coord2address(authorization, longitude, latitude);
+			if (kakaoMapResponse != null
+				&& kakaoMapResponse.getDocuments() != null
+				&& !kakaoMapResponse.getDocuments().isEmpty()
+				&& kakaoMapResponse.getDocuments().get(0).getAddress() != null) {
+				return kakaoMapResponse.getDocuments().get(0).getAddress().getAddressName();
+			}
+		} catch (Exception e) {
+			log.warn("카카오맵 역지오코딩 실패: {}", e.getMessage());
+			throw new ExternalApiException("카카오맵 역지오코딩 중 오류가 발생했습니다.");
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/traveljournal/infra/kakaoMap/util/KakaoMapFeignClient.java
+++ b/src/main/java/com/traveljournal/infra/kakaoMap/util/KakaoMapFeignClient.java
@@ -1,0 +1,19 @@
+package com.traveljournal.infra.kakaoMap.util;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.traveljournal.infra.kakaoMap.dto.KakaoMapResponse;
+
+@FeignClient(name = "kakaoMapClient", url = "https://dapi.kakao.com")
+public interface KakaoMapFeignClient {
+
+	@GetMapping("/v2/local/geo/coord2address.json")
+	KakaoMapResponse coord2address(
+		@RequestHeader("Authorization") String authorization,
+		@RequestParam("x") double longitude,
+		@RequestParam("y") double latitude
+	);
+}


### PR DESCRIPTION
## 🔥 해결된 이슈
- Closes #51 

## 📌 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련된 테스트를 추가하거나 기존 테스트를 실행하여 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드를 따랐는지 확인했습니다.
- [x] 배포가 필요한 경우 관련 작업을 완료했습니다. (예: CI/CD 설정, 환경 변수 추가 등)

## ✨ 작업 내용
- 외부 API 연동(카카오맵)시 Hexagonal Architecture(Ports & Adapters)를 적용하여 도메인과 인프라 계층을 명확히 분리하였습니다.

- 사진 메타데이터(촬영일시, 위도, 경도) 추출 및 역지오코딩 기능 구현

## 🚀 추가 설명
- 기존 구조에서는 외부 API 연동 코드가 도메인 로직과 혼재되어 있어 유지보수와 테스트가 어려웠습니다.

- Hexagonal Architecture를 적용하여 재사용성과 테스트 용이성을 크게 개선하였습니다.

- GeoAddressLookupPort 인터페이스를 도메인 계층에 정의하고, infra 계층에서 실제 구현체를 관리합니다.

- 참고
> https://tech.kakaopay.com/post/home-hexagonal-architecture/
https://java-design-patterns.com/patterns/separated-interface/#separated-interface-pattern-tutorials
https://codesoapbox.dev/ports-adapters-aka-hexagonal-architecture-explained/

## 📸 테스트 결과 (스크린샷 혹은 로그)
> [스크린샷 혹은 테스트 정상 확인 로그를 첨부해주세요.]
![Pasted Graphic 5](https://github.com/user-attachments/assets/73cd384f-8dbe-4d29-93da-f921e8789890)
![Pasted Graphic 6](https://github.com/user-attachments/assets/73a861e0-8629-48ae-8236-133c87cc2e00)
