### PR TITLE
[Feature] 차단 기능 추가(홈, 플레이스, 여행일지 등), 통계 기능 구현, 탐험일지 랜덤 최적화, 더미데이터 -> 실제 데이터로 변경 등

### DIFF
--- a/src/main/java/com/traveljournal/domain/Image/service/ImageInfoService.java
+++ b/src/main/java/com/traveljournal/domain/Image/service/ImageInfoService.java
@@ -1,0 +1,21 @@
+package com.traveljournal.domain.Image.service;
+
+import org.springframework.stereotype.Service;
+
+import com.traveljournal.domain.Image.entity.ImageInfo;
+import com.traveljournal.domain.Image.repository.ImageInfoRepository;
+import com.traveljournal.global.exception.BadRequestException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ImageInfoService {
+
+	private final ImageInfoRepository imageInfoRepository;
+	public ImageInfo getImageInfo(String filename) {
+
+		return imageInfoRepository.findByFilename((filename))
+			.orElseThrow(() -> new BadRequestException("이미지 정보가 없습니다: " + filename));
+	}
+}

--- a/src/main/java/com/traveljournal/domain/block/dto/BlockRelationType.java
+++ b/src/main/java/com/traveljournal/domain/block/dto/BlockRelationType.java
@@ -1,0 +1,14 @@
+package com.traveljournal.domain.block.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public enum BlockRelationType {
+	@Schema(description = "차단 아님")
+	NONE,
+	@Schema(description = "내가 차단")
+	BLOCKED_BY_ME,
+	@Schema(description = "상대가 나를 차단")
+	BLOCKED_ME,
+	@Schema(description = "상호 차단")
+	MUTUAL_BLOCK
+}

--- a/src/main/java/com/traveljournal/domain/block/repository/BlockRepository.java
+++ b/src/main/java/com/traveljournal/domain/block/repository/BlockRepository.java
@@ -1,15 +1,16 @@
 package com.traveljournal.domain.block.repository;
 
-import com.traveljournal.domain.block.entity.Block;
-import com.traveljournal.domain.member.entity.Member;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-import java.util.Optional;
+import com.traveljournal.domain.block.entity.Block;
+import com.traveljournal.domain.member.entity.Member;
 
 public interface BlockRepository extends JpaRepository<Block, Long> {
     boolean existsByBlockerAndBlocked(Member blocker, Member blocked);
@@ -19,4 +20,6 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
 
     @Query("SELECT b.blocked.id FROM Block b WHERE b.blocker.id = :blockerId")
     List<Long> findBlockedMemberIdsByBlockerId(@Param("blockerId") Long blockerId);
+
+    boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
 }

--- a/src/main/java/com/traveljournal/domain/block/repository/BlockRepository.java
+++ b/src/main/java/com/traveljournal/domain/block/repository/BlockRepository.java
@@ -22,4 +22,7 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
     List<Long> findBlockedMemberIdsByBlockerId(@Param("blockerId") Long blockerId);
 
     boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+
+    @Query("SELECT b.blocker.id FROM Block b WHERE b.blocked.id = :blockedId")
+    List<Long> findBlockerIdsByBlockedId(@Param("blockedId") Long blockedId);
 }

--- a/src/main/java/com/traveljournal/domain/block/service/BlockService.java
+++ b/src/main/java/com/traveljournal/domain/block/service/BlockService.java
@@ -21,75 +21,80 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class BlockService {
-    private final BlockRepository blockRepository;
-    private final MemberService memberService;
-    private Member findMemberById(Long id) {return memberService.findById(id);}
-    @Transactional
-    public void blockMember(Long blockerId, Long blockedId) {
+	private final BlockRepository blockRepository;
+	private final MemberService memberService;
 
-        Member blocker = findMemberById(blockerId);
-        Member blocked = findMemberById(blockedId);
+	private Member findMemberById(Long id) {
+		return memberService.findById(id);
+	}
 
-        if (blockRepository.existsByBlockerAndBlocked(blocker, blocked)) {
-            throw new BlockBadRequestException("이미 차단한 사용자입니다.");
-        }
+	@Transactional
+	public void blockMember(Long blockerId, Long blockedId) {
 
-        Block block = Block.builder()
-                .blocker(blocker)
-                .blocked(blocked)
-                .build();
+		Member blocker = findMemberById(blockerId);
+		Member blocked = findMemberById(blockedId);
 
-        blockRepository.save(block);
-    }
+		if (blockRepository.existsByBlockerAndBlocked(blocker, blocked)) {
+			throw new BlockBadRequestException("이미 차단한 사용자입니다.");
+		}
 
-    public void unblockMember(Long blockerId, Long blockedId) {
-        Member blocker = findMemberById(blockerId);
-        Member blocked = findMemberById(blockedId);
+		Block block = Block.builder()
+			.blocker(blocker)
+			.blocked(blocked)
+			.build();
 
-        Block block = blockRepository.findByBlockerAndBlocked(blocker, blocked)
-                .orElseThrow(()-> new BlockBadRequestException("차단 내역이 없습니다."));
+		blockRepository.save(block);
+	}
 
-        blockRepository.delete(block);
-    }
+	public void unblockMember(Long blockerId, Long blockedId) {
+		Member blocker = findMemberById(blockerId);
+		Member blocked = findMemberById(blockedId);
 
-    @Transactional(readOnly = true)
-    public Page<BlockResponse> getBlockedMembers(Long blockerId, Pageable pageable) {
-        Member blocker = findMemberById(blockerId);
-        return blockRepository.findAllByBlocker(blocker, pageable)
-                .map(block -> BlockResponse.of(block.getBlocked()));
-    }
+		Block block = blockRepository.findByBlockerAndBlocked(blocker, blocked)
+			.orElseThrow(() -> new BlockBadRequestException("차단 내역이 없습니다."));
 
-    @Transactional(readOnly = true)
-    public boolean isBlocked(Member viewer, Member target) {
-        return blockRepository.existsByBlockerAndBlocked(viewer, target) ||
-                blockRepository.existsByBlockerAndBlocked(target, viewer);
-    }
+		blockRepository.delete(block);
+	}
 
-    private BlockRelationType getBlockRelation(Long viewerId, Long memberId) {
-        boolean blockedByMe = blockRepository.existsByBlockerIdAndBlockedId(viewerId, memberId);
-        boolean blockedMe = blockRepository.existsByBlockerIdAndBlockedId(memberId, viewerId);
+	@Transactional(readOnly = true)
+	public Page<BlockResponse> getBlockedMembers(Long blockerId, Pageable pageable) {
+		Member blocker = findMemberById(blockerId);
+		return blockRepository.findAllByBlocker(blocker, pageable)
+			.map(block -> BlockResponse.of(block.getBlocked()));
+	}
 
-        if (blockedByMe && blockedMe) {
-            return BlockRelationType.MUTUAL_BLOCK;
-        } else if (blockedByMe) {
-            return BlockRelationType.BLOCKED_BY_ME;
-        } else if (blockedMe) {
-            return BlockRelationType.BLOCKED_ME;
-        } else {
-            return BlockRelationType.NONE;
-        }
-    }
+	@Transactional(readOnly = true)
+	public boolean isBlocked(Member viewer, Member target) {
+		return blockRepository.existsByBlockerAndBlocked(viewer, target) ||
+			blockRepository.existsByBlockerAndBlocked(target, viewer);
+	}
 
-    @Transactional(readOnly = true)
-    public List<Long> getBlockedMemberIds(Long viewerId) {
-        return blockRepository.findBlockedMemberIdsByBlockerId(viewerId);
-    }
+	@Transactional(readOnly = true)
+	public BlockRelationType getBlockRelation(Long viewerId, Long memberId) {
+		boolean blockedByMe = blockRepository.existsByBlockerIdAndBlockedId(viewerId, memberId);
+		boolean blockedMe = blockRepository.existsByBlockerIdAndBlockedId(memberId, viewerId);
 
-    @Transactional
-    public void validateNotBlocked(Long viewerId, Long memberId) {
-        BlockRelationType relation = getBlockRelation(viewerId, memberId);
-        if (relation != BlockRelationType.NONE) {
-            throw new ForbiddenException("차단된 회원입니다.");
-        }
-    }
+		if (blockedByMe && blockedMe) {
+			return BlockRelationType.MUTUAL_BLOCK;
+		} else if (blockedByMe) {
+			return BlockRelationType.BLOCKED_BY_ME;
+		} else if (blockedMe) {
+			return BlockRelationType.BLOCKED_ME;
+		} else {
+			return BlockRelationType.NONE;
+		}
+	}
+
+	@Transactional(readOnly = true)
+	public List<Long> getBlockedMemberIds(Long viewerId) {
+		return blockRepository.findBlockedMemberIdsByBlockerId(viewerId);
+	}
+
+	@Transactional(readOnly = true)
+	public void validateNotBlocked(Long viewerId, Long memberId) {
+		BlockRelationType relation = getBlockRelation(viewerId, memberId);
+		if (relation != BlockRelationType.NONE) {
+			throw new ForbiddenException("차단된 회원입니다.");
+		}
+	}
 }

--- a/src/main/java/com/traveljournal/domain/block/service/BlockService.java
+++ b/src/main/java/com/traveljournal/domain/block/service/BlockService.java
@@ -1,16 +1,21 @@
 package com.traveljournal.domain.block.service;
 
-import com.traveljournal.domain.block.dto.BlockResponse;
-import com.traveljournal.domain.block.entity.Block;
-import com.traveljournal.domain.member.entity.Member;
-import com.traveljournal.domain.block.repository.BlockRepository;
-import com.traveljournal.domain.member.service.MemberService;
-import com.traveljournal.global.exception.BlockBadRequestException;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.traveljournal.domain.block.dto.BlockRelationType;
+import com.traveljournal.domain.block.dto.BlockResponse;
+import com.traveljournal.domain.block.entity.Block;
+import com.traveljournal.domain.block.repository.BlockRepository;
+import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.service.MemberService;
+import com.traveljournal.global.exception.BlockBadRequestException;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -57,5 +62,26 @@ public class BlockService {
     public boolean isBlocked(Member viewer, Member target) {
         return blockRepository.existsByBlockerAndBlocked(viewer, target) ||
                 blockRepository.existsByBlockerAndBlocked(target, viewer);
+    }
+
+    @Transactional(readOnly = true)
+    public BlockRelationType getBlockRelation(Member viewer, Member target) {
+        boolean blockedByMe = blockRepository.existsByBlockerAndBlocked(viewer, target);
+        boolean blockedMe = blockRepository.existsByBlockerAndBlocked(target, viewer);
+
+        if (blockedByMe && blockedMe) {
+            return BlockRelationType.MUTUAL_BLOCK;
+        } else if (blockedByMe) {
+            return BlockRelationType.BLOCKED_BY_ME;
+        } else if (blockedMe) {
+            return BlockRelationType.BLOCKED_ME;
+        } else {
+            return BlockRelationType.NONE;
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> getBlockedMemberIds(Long viewerId) {
+        return blockRepository.findBlockedMemberIdsByBlockerId(viewerId);
     }
 }

--- a/src/main/java/com/traveljournal/domain/block/service/BlockService.java
+++ b/src/main/java/com/traveljournal/domain/block/service/BlockService.java
@@ -14,6 +14,7 @@ import com.traveljournal.domain.block.repository.BlockRepository;
 import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.global.exception.BlockBadRequestException;
+import com.traveljournal.global.exception.ForbiddenException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -64,10 +65,9 @@ public class BlockService {
                 blockRepository.existsByBlockerAndBlocked(target, viewer);
     }
 
-    @Transactional(readOnly = true)
-    public BlockRelationType getBlockRelation(Member viewer, Member target) {
-        boolean blockedByMe = blockRepository.existsByBlockerAndBlocked(viewer, target);
-        boolean blockedMe = blockRepository.existsByBlockerAndBlocked(target, viewer);
+    private BlockRelationType getBlockRelation(Long viewerId, Long memberId) {
+        boolean blockedByMe = blockRepository.existsByBlockerIdAndBlockedId(viewerId, memberId);
+        boolean blockedMe = blockRepository.existsByBlockerIdAndBlockedId(memberId, viewerId);
 
         if (blockedByMe && blockedMe) {
             return BlockRelationType.MUTUAL_BLOCK;
@@ -83,5 +83,13 @@ public class BlockService {
     @Transactional(readOnly = true)
     public List<Long> getBlockedMemberIds(Long viewerId) {
         return blockRepository.findBlockedMemberIdsByBlockerId(viewerId);
+    }
+
+    @Transactional
+    public void validateNotBlocked(Long viewerId, Long memberId) {
+        BlockRelationType relation = getBlockRelation(viewerId, memberId);
+        if (relation != BlockRelationType.NONE) {
+            throw new ForbiddenException("차단된 회원입니다.");
+        }
     }
 }

--- a/src/main/java/com/traveljournal/domain/block/service/BlockService.java
+++ b/src/main/java/com/traveljournal/domain/block/service/BlockService.java
@@ -1,6 +1,7 @@
 package com.traveljournal.domain.block.service;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -87,7 +88,12 @@ public class BlockService {
 
 	@Transactional(readOnly = true)
 	public List<Long> getBlockedMemberIds(Long viewerId) {
-		return blockRepository.findBlockedMemberIdsByBlockerId(viewerId);
+
+		List<Long> blockedByMe = blockRepository.findBlockedMemberIdsByBlockerId(viewerId);
+		List<Long> blockedMe = blockRepository.findBlockerIdsByBlockedId(viewerId);
+		return Stream.concat(blockedByMe.stream(), blockedMe.stream())
+			.distinct()
+			.toList();
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/traveljournal/domain/explore/service/ExploreFeedService.java
+++ b/src/main/java/com/traveljournal/domain/explore/service/ExploreFeedService.java
@@ -1,11 +1,12 @@
 package com.traveljournal.domain.explore.service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -14,13 +15,14 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.traveljournal.domain.block.service.BlockService;
 import com.traveljournal.domain.explore.dto.ExploreJournalFeedResponse;
 import com.traveljournal.domain.explore.entity.ExploreSeenJournal;
 import com.traveljournal.domain.explore.repository.ExploreSeenJournalRepository;
+import com.traveljournal.domain.follow.repository.FollowRepository;
 import com.traveljournal.domain.journal.entity.Journal;
 import com.traveljournal.domain.journal.repository.JournalRepository;
 import com.traveljournal.domain.member.entity.Member;
-import com.traveljournal.domain.follow.repository.FollowRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,14 +33,18 @@ public class ExploreFeedService {
 	private final FollowRepository followRepository;
 	private final JournalRepository journalRepository;
 	private final ExploreSeenJournalRepository exploreSeenJournalRepository;
+	private final BlockService blockService;
 
 	@Transactional(readOnly = true)
 	public Page<ExploreJournalFeedResponse> getExploreFeed(Long memberId, Pageable pageable) {
 		List<Long> followingIds = followRepository.findAcceptedToMemberIdsByFromMemberId(memberId);
 
+		List<Long> blockedIds = blockService.getBlockedMemberIds(memberId);
+		boolean hasBlockedMembers = blockedIds != null && !blockedIds.isEmpty();
+
 		// 1. 팔로우한 회원이 없으면 바로 랜덤 피드
 		if (followingIds == null || followingIds.isEmpty()) {
-			return getOptimizedRandomFeed(memberId, List.of(), List.of(), pageable);
+			return getOptimizedRandomFeed(memberId, List.of(), List.of(), blockedIds, pageable);
 		}
 
 		// 2. 이미 본 일지 목록 조회
@@ -47,15 +53,25 @@ public class ExploreFeedService {
 		// 3. 페이징 최적화: 필요한 ID만 먼저 조회
 		Page<Long> journalIdPage;
 		if (seenJournalIds == null || seenJournalIds.isEmpty()) {
-			journalIdPage = journalRepository.findIdsByMemberIdInOrderByCreatedAtDesc(followingIds, pageable);
+			if (hasBlockedMembers) {
+				journalIdPage = journalRepository.findIdsByMemberIdInExcludingBlocked(followingIds, blockedIds,
+					pageable);
+			} else {
+				journalIdPage = journalRepository.findIdsByMemberIdInOrderByCreatedAtDesc(followingIds, pageable);
+			}
 		} else {
-			journalIdPage = journalRepository.findIdsByMemberIdInAndIdNotInOrderByCreatedAtDesc(
-				followingIds, seenJournalIds, pageable);
+			if (hasBlockedMembers) {
+				journalIdPage = journalRepository.findIdsByMemberIdInAndIdNotInExcludingBlocked(
+					followingIds, seenJournalIds, blockedIds, pageable);
+			} else {
+				journalIdPage = journalRepository.findIdsByMemberIdInAndIdNotInOrderByCreatedAtDesc(
+					followingIds, seenJournalIds, pageable);
+			}
 		}
 
 		// 4. 팔로우한 회원의 읽지 않은 게시글이 없으면 랜덤 피드
 		if (journalIdPage.isEmpty()) {
-			return getOptimizedRandomFeed(memberId, followingIds, seenJournalIds, pageable);
+			return getOptimizedRandomFeed(memberId, followingIds, seenJournalIds, blockedIds, pageable);
 		}
 
 		// 5. fetch join으로 필요한 데이터만 한 번에 조회
@@ -75,56 +91,63 @@ public class ExploreFeedService {
 	}
 
 	private Page<ExploreJournalFeedResponse> getOptimizedRandomFeed(
-		Long memberId, List<Long> followingIds, List<Long> seenJournalIds, Pageable pageable) {
+		Long memberId, List<Long> followingIds, List<Long> seenJournalIds, List<Long> blockedIds, Pageable pageable) {
 
 		int limit = pageable.getPageSize();
-		List<Long> notFollowMemberIds = (followingIds == null || followingIds.isEmpty())
-			? List.of(memberId)
-			: Stream.concat(followingIds.stream(), Stream.of(memberId)).toList();
+		boolean hasBlockedMembers = blockedIds != null && !blockedIds.isEmpty();
+		boolean hasFollowing = followingIds != null && !followingIds.isEmpty();
+		boolean hasSeenJournals = seenJournalIds != null && !seenJournalIds.isEmpty();
 
-		// 7. 최적화된 랜덤 조회 사용
+		List<Long> excludeMemberIds = new ArrayList<>();
+		excludeMemberIds.add(memberId);
+		if (hasBlockedMembers) {
+			excludeMemberIds.addAll(blockedIds);
+		}
+		if (hasFollowing) {
+			excludeMemberIds.addAll(followingIds);
+		}
+		excludeMemberIds = excludeMemberIds.stream().distinct().toList();
+
 		List<Long> randomJournalIds;
-		if (notFollowMemberIds.size() == 1 && notFollowMemberIds.contains(memberId)) {
-			if (seenJournalIds == null || seenJournalIds.isEmpty()) {
-				randomJournalIds = journalRepository.findOptimizedRandomAll(limit);
-			} else {
-				randomJournalIds = journalRepository.findOptimizedRandomIdsByMemberIdNotIn(
-					List.of(memberId), seenJournalIds, limit
-				);
-			}
+
+		if (!hasSeenJournals) {
+			randomJournalIds = journalRepository.findRandomIdsByMemberIdNotIn(excludeMemberIds, limit);
 		} else {
 			randomJournalIds = journalRepository.findOptimizedRandomIdsByMemberIdNotIn(
-				notFollowMemberIds, seenJournalIds == null ? List.of() : seenJournalIds, limit
+				excludeMemberIds, seenJournalIds, limit
 			);
 		}
 
-		// 8. 최적화 실패 시
 		if (randomJournalIds.isEmpty()) {
-			if (notFollowMemberIds.size() == 1 && notFollowMemberIds.contains(memberId)) {
-				if (seenJournalIds == null || seenJournalIds.isEmpty()) {
-					randomJournalIds = journalRepository.findRandomAll(limit);
-				} else {
-					randomJournalIds = journalRepository.findRandomIdsByMemberIdNotInAndIdNotIn(
-						List.of(memberId), seenJournalIds, limit
-					);
-				}
+			if (!hasSeenJournals) {
+				randomJournalIds = journalRepository.findRandomIdsByMemberIdNotIn(excludeMemberIds, limit);
 			} else {
-				randomJournalIds = journalRepository.findRandomIdsByMemberIdNotInAndIdNotIn(
-					notFollowMemberIds, seenJournalIds == null ? List.of() : seenJournalIds, limit
+				randomJournalIds = journalRepository.findOptimizedRandomIdsByMemberIdNotIn(
+					excludeMemberIds, seenJournalIds, limit
 				);
 			}
 		}
 
-		// 9. 데이터 한 번에 조회
 		List<Journal> journals = journalRepository.findAllByIdInFetchJoin(randomJournalIds);
 
-		List<ExploreJournalFeedResponse> content = journals.stream()
+		Map<Long, Journal> journalMap = journals.stream()
+			.collect(Collectors.toMap(Journal::getId, j -> j));
+
+		List<Journal> orderedJournals = randomJournalIds.stream()
+			.map(journalMap::get)
+			.filter(Objects::nonNull)
+			.collect(Collectors.toList());
+
+		Collections.shuffle(orderedJournals);
+
+		List<ExploreJournalFeedResponse> content = orderedJournals.stream()
 			.map(j -> ExploreJournalFeedResponse.of(j, j.getMember()))
 			.toList();
 
-		// 10. 랜덤 데이터는 정확한 총 개수를 알기 어려움
-		return new PageImpl<>(content, pageable,
-			content.size() < limit ? content.size() : pageable.getOffset() + content.size() + 1);
+		long totalElements = journalRepository.countAvailableJournalsForRandomFeed(excludeMemberIds,
+			hasSeenJournals ? seenJournalIds : List.of());
+
+		return new PageImpl<>(content, pageable, totalElements);
 	}
 
 	@Transactional
@@ -157,5 +180,11 @@ public class ExploreFeedService {
 		// 주기적으로 오래된 데이터 정리
 		LocalDateTime cutoff = LocalDateTime.now().minusDays(3);
 		exploreSeenJournalRepository.deleteAllBySeenAtBefore(cutoff);
+	}
+
+	@Scheduled(cron = "0 0 2 * * *")
+	@Transactional
+	public void refreshRandomIndex() {
+		journalRepository.updateRandomIndex();
 	}
 }

--- a/src/main/java/com/traveljournal/domain/follow/service/FollowService.java
+++ b/src/main/java/com/traveljournal/domain/follow/service/FollowService.java
@@ -2,7 +2,6 @@ package com.traveljournal.domain.follow.service;
 
 import java.util.List;
 
-import com.traveljournal.domain.member.service.MemberService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -11,9 +10,11 @@ import org.springframework.transaction.annotation.Transactional;
 import com.traveljournal.domain.follow.dto.FollowProfileResponse;
 import com.traveljournal.domain.follow.dto.FollowRequestResponse;
 import com.traveljournal.domain.follow.entity.Follow;
-import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.follow.entity.RequestStatus;
 import com.traveljournal.domain.follow.repository.FollowRepository;
+import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.member.service.MemberService;
+import com.traveljournal.domain.statistics.service.MemberStatisticsService;
 import com.traveljournal.global.exception.FollowAccountScopeException;
 import com.traveljournal.global.exception.FollowBadRequestException;
 import com.traveljournal.global.exception.FollowNotFoundException;
@@ -23,109 +24,127 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class FollowService {
-    private final FollowRepository followRepository;
-    private final MemberService memberService;
-    private Member findMemberById(Long id) {return memberService.findById(id);}
-    @Transactional
-    public String follow(Long fromMemberId, Long toMemberId) {
-        if (fromMemberId.equals(toMemberId)) {
-            throw new FollowBadRequestException("자신을 팔로우 할 수 없습니다.");
-        }
+	private final FollowRepository followRepository;
+	private final MemberService memberService;
+	private final MemberStatisticsService memberStatisticsService;
 
-        if(followRepository.existsByFromMemberIdAndToMemberId(fromMemberId, toMemberId)) {
-            throw new FollowBadRequestException("이미 팔로우한 사용자입니다.");
-        }
-        Member fromMember = findMemberById(fromMemberId);
-        Member toMember = findMemberById(toMemberId);
+	private Member findMemberById(Long id) {
+		return memberService.findById(id);
+	}
 
-        RequestStatus status;
-        String message;
+	@Transactional
+	public String follow(Long fromMemberId, Long toMemberId) {
+		if (fromMemberId.equals(toMemberId)) {
+			throw new FollowBadRequestException("자신을 팔로우 할 수 없습니다.");
+		}
 
-        switch (toMember.getAccountScope()) {
-            case PUBLIC -> {
-                status = RequestStatus.ACCEPTED;
-                message = "팔로우 성공";
-            }
-            case FRIENDS, PRIVATE -> {
-                status = RequestStatus.REQUESTED;
-                message = "팔로우 요청 성공";
-            }
-            default -> throw new FollowAccountScopeException("알 수 없는 계정 범위입니다.");
-        }
+		if (followRepository.existsByFromMemberIdAndToMemberId(fromMemberId, toMemberId)) {
+			throw new FollowBadRequestException("이미 팔로우한 사용자입니다.");
+		}
+		Member fromMember = findMemberById(fromMemberId);
+		Member toMember = findMemberById(toMemberId);
 
-        Follow follow = Follow.builder()
-                .fromMember(fromMember)
-                .toMember(toMember)
-                .requestStatus(status)
-                .build();
+		RequestStatus status;
+		String message;
 
-        followRepository.save(follow);
-        return message;
-    }
+		switch (toMember.getAccountScope()) {
+			case PUBLIC -> {
+				status = RequestStatus.ACCEPTED;
+				message = "팔로우 성공";
+			}
+			case FRIENDS, PRIVATE -> {
+				status = RequestStatus.REQUESTED;
+				message = "팔로우 요청 성공";
+			}
+			default -> throw new FollowAccountScopeException("알 수 없는 계정 범위입니다.");
+		}
 
-    @Transactional
-    public void unfollow(Long fromMemberId, Long toMemberId) {
-        Follow follow = followRepository.findByFromMemberIdAndToMemberIdAndRequestStatus(
-                fromMemberId, toMemberId, RequestStatus.ACCEPTED
-        ).orElseThrow(()-> new FollowNotFoundException("팔로우 관계가 존재하지 않거나, 아직 수락되지 않았습니다."));
-        followRepository.deleteByFromMemberIdAndToMemberId(fromMemberId, toMemberId);
-    }
+		Follow follow = Follow.builder()
+			.fromMember(fromMember)
+			.toMember(toMember)
+			.requestStatus(status)
+			.build();
 
-    // 내가 팔로우한 사람들
-    @Transactional(readOnly = true)
-    public Page<FollowProfileResponse> findFollowings(Long memberId, Pageable pageable) {
-        Member member = findMemberById(memberId);
-        return followRepository.findByFromMemberAndRequestStatus(member, RequestStatus.ACCEPTED, pageable)
-                .map(follow -> FollowProfileResponse.of(follow.getToMember()));
-    }
+		followRepository.save(follow);
 
-    // 나를 팔로우하는 사람들
-    @Transactional(readOnly = true)
-    public Page<FollowProfileResponse> findFollowers(Long memberId, Pageable pageable) {
-        Member member = findMemberById(memberId);
-        return followRepository.findByToMemberAndRequestStatus(member, RequestStatus.ACCEPTED, pageable)
-                .map(follow -> FollowProfileResponse.of(follow.getFromMember()));
-    }
+		if (status == RequestStatus.ACCEPTED) {
+			memberStatisticsService.increaseFollowerCount(toMemberId);
+			memberStatisticsService.increaseFollowingCount(fromMemberId);
+		}
 
-    @Transactional(readOnly = true)
-    public long getFollowerCount(Long memberId) {
-        Member member = findMemberById(memberId);
-        return followRepository.countByToMemberAndRequestStatus(member, RequestStatus.ACCEPTED);
-    }
+		return message;
+	}
 
-    @Transactional(readOnly = true)
-    public long getFollowingCount(Long memberId) {
-        Member member = findMemberById(memberId);
-        return followRepository.countByFromMemberAndRequestStatus(member, RequestStatus.ACCEPTED);
-    }
+	@Transactional
+	public void unfollow(Long fromMemberId, Long toMemberId) {
+		Follow follow = followRepository.findByFromMemberIdAndToMemberIdAndRequestStatus(
+			fromMemberId, toMemberId, RequestStatus.ACCEPTED
+		).orElseThrow(() -> new FollowNotFoundException("팔로우 관계가 존재하지 않거나, 아직 수락되지 않았습니다."));
+		followRepository.deleteByFromMemberIdAndToMemberId(fromMemberId, toMemberId);
+		memberStatisticsService.decreaseFollowerCount(toMemberId);
+		memberStatisticsService.decreaseFollowingCount(fromMemberId);
+	}
 
-    @Transactional(readOnly = true)
-    public boolean isFollowing(Long followerId, Long followingId) {
-        return followRepository.existsByFromMemberIdAndToMemberIdAndRequestStatus(followerId, followingId, RequestStatus.ACCEPTED);
-    }
+	// 내가 팔로우한 사람들
+	@Transactional(readOnly = true)
+	public Page<FollowProfileResponse> findFollowings(Long memberId, Pageable pageable) {
+		Member member = findMemberById(memberId);
+		return followRepository.findByFromMemberAndRequestStatus(member, RequestStatus.ACCEPTED, pageable)
+			.map(follow -> FollowProfileResponse.of(follow.getToMember()));
+	}
 
-    @Transactional
-    public void acceptFollowRequest(Long memberId, Long followId) {
-        Follow follow = followRepository.findByIdAndToMemberId(followId, memberId)
-                .orElseThrow(()-> new FollowNotFoundException("팔로우 요청이 존재하지 않습니다."));
-        follow.accept();
-    }
+	// 나를 팔로우하는 사람들
+	@Transactional(readOnly = true)
+	public Page<FollowProfileResponse> findFollowers(Long memberId, Pageable pageable) {
+		Member member = findMemberById(memberId);
+		return followRepository.findByToMemberAndRequestStatus(member, RequestStatus.ACCEPTED, pageable)
+			.map(follow -> FollowProfileResponse.of(follow.getFromMember()));
+	}
 
-    @Transactional
-    public void rejectFollowRequest(Long memberId, Long followId) {
-        Follow follow = followRepository.findByIdAndToMemberId(followId, memberId)
-                .orElseThrow(()-> new FollowNotFoundException("팔로우 요청이 존재하지 않습니다."));
-        follow.reject();
-    }
+	@Transactional(readOnly = true)
+	public long getFollowerCount(Long memberId) {
+		Member member = findMemberById(memberId);
+		return followRepository.countByToMemberAndRequestStatus(member, RequestStatus.ACCEPTED);
+	}
 
-    @Transactional(readOnly = true)
-    public Page<FollowRequestResponse> findFollowRequests(Long memberId, Pageable pageable) {
-        return followRepository.findAllByToMemberIdAndRequestStatus(memberId, RequestStatus.REQUESTED, pageable)
-                .map(FollowRequestResponse::of);
-    }
+	@Transactional(readOnly = true)
+	public long getFollowingCount(Long memberId) {
+		Member member = findMemberById(memberId);
+		return followRepository.countByFromMemberAndRequestStatus(member, RequestStatus.ACCEPTED);
+	}
 
-    @Transactional(readOnly = true)
-    public List<Long> getFollowingMemberIds(Long followerId) {
-        return followRepository.findFollowedIdsByFollowerId(followerId);
-    }
+	@Transactional(readOnly = true)
+	public boolean isFollowing(Long followerId, Long followingId) {
+		return followRepository.existsByFromMemberIdAndToMemberIdAndRequestStatus(followerId, followingId,
+			RequestStatus.ACCEPTED);
+	}
+
+	@Transactional
+	public void acceptFollowRequest(Long memberId, Long followId) {
+		Follow follow = followRepository.findByIdAndToMemberId(followId, memberId)
+			.orElseThrow(() -> new FollowNotFoundException("팔로우 요청이 존재하지 않습니다."));
+		if (follow.getRequestStatus() == RequestStatus.REQUESTED) {
+			follow.accept();
+			memberStatisticsService.increaseFollowerCount(follow.getToMember().getId());
+			memberStatisticsService.increaseFollowingCount(follow.getFromMember().getId());
+		}
+	}
+
+	@Transactional
+	public void rejectFollowRequest(Long memberId, Long followId) {
+		Follow follow = followRepository.findByIdAndToMemberId(followId, memberId)
+			.orElseThrow(() -> new FollowNotFoundException("팔로우 요청이 존재하지 않습니다."));
+		follow.reject();
+	}
+
+	@Transactional(readOnly = true)
+	public Page<FollowRequestResponse> findFollowRequests(Long memberId, Pageable pageable) {
+		return followRepository.findAllByToMemberIdAndRequestStatus(memberId, RequestStatus.REQUESTED, pageable)
+			.map(FollowRequestResponse::of);
+	}
+
+	@Transactional(readOnly = true)
+	public List<Long> getFollowingMemberIds(Long followerId) {
+		return followRepository.findFollowedIdsByFollowerId(followerId);
+	}
 }

--- a/src/main/java/com/traveljournal/domain/hashtag/service/HashTagService.java
+++ b/src/main/java/com/traveljournal/domain/hashtag/service/HashTagService.java
@@ -1,0 +1,27 @@
+package com.traveljournal.domain.hashtag.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.traveljournal.domain.hashtag.entity.HashTag;
+import com.traveljournal.domain.hashtag.repository.HashTagRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class HashTagService {
+	private final HashTagRepository hashTagRepository;
+
+	public List<HashTag> getOrCreateHashTags(List<String> tagNames) {
+		List<HashTag> tags = new ArrayList<>();
+		for (String tagName : tagNames) {
+			HashTag tag = hashTagRepository.findByTagName(tagName)
+				.orElseGet(() -> hashTagRepository.save(HashTag.of(tagName)));
+			tags.add(tag);
+		}
+		return tags;
+	}
+}

--- a/src/main/java/com/traveljournal/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/traveljournal/domain/journal/controller/JournalController.java
@@ -49,8 +49,9 @@ public class JournalController {
 		@Parameter(description = "수도권, 강원도, 충정도, 경상도, 전라도, 제주도")
 		@PathVariable String regionName,
 		@ParameterObject @PageableDefault Pageable pageable) {
+		Long currentMemberId = SecurityUtil.getCurrentMemberId();
 		return ApiResponseHandler.getObjectSuccess(
-			journalService.findJournalsByRegionWithPaging(memberId, regionName, pageable));
+			journalService.findJournalsByRegionWithPaging(memberId, currentMemberId, regionName, pageable));
 	}
 
 	@Operation(
@@ -63,7 +64,8 @@ public class JournalController {
 		@Parameter(description = "조회할 member_id")
 		@PathVariable Long memberId,
 		@ParameterObject @PageableDefault Pageable pageable) {
-		return ApiResponseHandler.getObjectSuccess(journalService.findAllJournalsByMemberId(memberId, pageable));
+		Long currentMemberId = SecurityUtil.getCurrentMemberId();
+		return ApiResponseHandler.getObjectSuccess(journalService.findAllJournalsByMemberId(memberId, currentMemberId, pageable));
 	}
 
 	@PostMapping(value = "/members/journal/create")

--- a/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,17 +14,14 @@ import com.traveljournal.domain.journal.entity.Journal;
 public interface JournalRepository extends JpaRepository<Journal, Long> {
 
 	// 1단계: id만 페이징으로 조회
-	@Query("SELECT j.id FROM Journal j WHERE j.member.id = :memberId AND j.region IN :regions")
-	Page<Long> findIdsByMemberIdAndRegionIn(@Param("memberId") Long memberId, @Param("regions") List<String> regions, Pageable pageable);
-
 	@Query("""
-    SELECT DISTINCT j.id
-    FROM Journal j
-    LEFT JOIN j.hashTags h
-    WHERE j.title LIKE %:keyword%
-       OR j.region LIKE %:keyword%
-       OR h.tagName LIKE %:keyword%
-    """)
+		SELECT DISTINCT j.id
+		FROM Journal j
+		LEFT JOIN j.hashTags h
+		WHERE j.title LIKE %:keyword%
+		   OR j.region LIKE %:keyword%
+		   OR h.tagName LIKE %:keyword%
+		""")
 	Page<Long> findIdsByTitleOrRegionOrHashTagContaining(@Param("keyword") String keyword, Pageable pageable);
 
 	// 2단계: fetch join으로 실제 데이터 조회
@@ -37,64 +35,81 @@ public interface JournalRepository extends JpaRepository<Journal, Long> {
 	Page<Long> findIdsByMemberIdInOrderByCreatedAtDesc(@Param("memberIds") List<Long> memberIds, Pageable pageable);
 
 	@Query("SELECT j.id FROM Journal j WHERE j.member.id IN :memberIds AND j.id NOT IN :excludeJournalIds ORDER BY j.createdAt DESC")
-	Page<Long> findIdsByMemberIdInAndIdNotInOrderByCreatedAtDesc(@Param("memberIds") List<Long> memberIds, @Param("excludeJournalIds") List<Long> excludeJournalIds, Pageable pageable);
-
-	@Query(value = "SELECT j.id FROM journal j WHERE j.member_id NOT IN (:memberIds) AND j.id NOT IN (:excludeJournalIds) ORDER BY j.random_index LIMIT :limit", nativeQuery = true)
-	List<Long> findRandomIdsByMemberIdNotInAndIdNotIn(
-		@Param("memberIds") List<Long> memberIds,
-		@Param("excludeJournalIds") List<Long> excludeJournalIds,
-		@Param("limit") int limit
-	);
+	Page<Long> findIdsByMemberIdInAndIdNotInOrderByCreatedAtDesc(@Param("memberIds") List<Long> memberIds,
+		@Param("excludeJournalIds") List<Long> excludeJournalIds, Pageable pageable);
 
 	@Query("""
-    SELECT DISTINCT j.id
-    FROM Journal j
-    LEFT JOIN j.hashTags h
-    WHERE (j.title LIKE %:keyword%
-       OR j.region LIKE %:keyword%
-       OR h.tagName LIKE %:keyword%) AND j.member.id NOT IN :blockedMemberIds
-    """)
-	Page<Long> findIdsByKeywordExcludingBlockedMembers(@Param("keyword") String keyword, @Param("blockedMemberIds") List<Long> blockedMemberIds, Pageable pageable);
-
-	@Query(value = "SELECT j.id FROM journal j ORDER BY j.random_index LIMIT :limit", nativeQuery = true)
-	List<Long> findRandomAll(@Param("limit") int limit);
+		SELECT DISTINCT j.id
+		FROM Journal j
+		LEFT JOIN j.hashTags h
+		WHERE (j.title LIKE %:keyword%
+		   OR j.region LIKE %:keyword%
+		   OR h.tagName LIKE %:keyword%) AND j.member.id NOT IN :blockedMemberIds
+		""")
+	Page<Long> findIdsByKeywordExcludingBlockedMembers(@Param("keyword") String keyword,
+		@Param("blockedMemberIds") List<Long> blockedMemberIds, Pageable pageable);
 
 	@Query(value = """
-    SELECT j.id FROM journal j 
-    WHERE j.member_id NOT IN (:memberIds) AND j.id NOT IN (:excludeJournalIds) 
-    AND j.id >= (SELECT FLOOR(RAND() * (SELECT MAX(id) FROM journal)))
-    ORDER BY j.id
-    LIMIT :limit
-    """, nativeQuery = true)
+		SELECT j.id FROM journal j 
+		WHERE j.member_id NOT IN (:memberIds) 
+		AND (:excludeJournalIds IS NULL OR j.id NOT IN (:excludeJournalIds))
+		AND j.random_index >= RAND()
+		ORDER BY j.random_index
+		LIMIT :limit
+		""", nativeQuery = true)
 	List<Long> findOptimizedRandomIdsByMemberIdNotIn(
 		@Param("memberIds") List<Long> memberIds,
 		@Param("excludeJournalIds") List<Long> excludeJournalIds,
 		@Param("limit") int limit
 	);
 
-	@Query(value = """
-    SELECT j.id FROM journal j 
-    WHERE j.id >= (SELECT FLOOR(RAND() * (SELECT MAX(id) FROM journal)))
-    ORDER BY j.id
-    LIMIT :limit
-    """, nativeQuery = true)
-	List<Long> findOptimizedRandomAll(@Param("limit") int limit);
+	@Query("""
+		SELECT j.id FROM Journal j
+		WHERE j.member.id = :memberId
+		  AND j.region IN :regions
+		  AND (:blockedIds IS NULL OR j.member.id NOT IN :blockedIds)
+		""")
+	Page<Long> findIdsByMemberIdAndRegionInExcludingBlocked(@Param("memberId") Long memberId,
+		@Param("regions") List<String> regions, @Param("blockedIds") List<Long> blockedIds, Pageable pageable);
 
 	@Query("""
-    SELECT j.id FROM Journal j
-    WHERE j.member.id = :memberId
-      AND j.region IN :regions
-      AND (:blockedIds IS NULL OR j.member.id NOT IN :blockedIds)
-    """)
-	Page<Long> findIdsByMemberIdAndRegionInExcludingBlocked(@Param("memberId") Long memberId, @Param("regions") List<String> regions, @Param("blockedIds") List<Long> blockedIds, Pageable pageable);
-
-	@Query("""
-    SELECT j.id FROM Journal j
-    WHERE j.member.id = :memberId
-      AND (:blockedIds IS NULL OR j.member.id NOT IN :blockedIds)
-    """)
-	Page<Long> findIdsByMemberIdExcludingBlocked(@Param("memberId") Long memberId, @Param("blockedIds") List<Long> blockedIds, Pageable pageable);
+		SELECT j.id FROM Journal j
+		WHERE j.member.id = :memberId
+		  AND (:blockedIds IS NULL OR j.member.id NOT IN :blockedIds)
+		""")
+	Page<Long> findIdsByMemberIdExcludingBlocked(@Param("memberId") Long memberId,
+		@Param("blockedIds") List<Long> blockedIds, Pageable pageable);
 
 	@Query("SELECT j.region, COUNT(j) FROM Journal j WHERE j.member.id = :memberId GROUP BY j.region")
 	List<Object[]> countJournalsByRegion(@Param("memberId") Long memberId);
+
+	@Query("SELECT j.id FROM Journal j WHERE j.member.id IN :memberIds AND j.member.id NOT IN :blockedIds ORDER BY j.createdAt DESC")
+	Page<Long> findIdsByMemberIdInExcludingBlocked(@Param("memberIds") List<Long> memberIds,
+		@Param("blockedIds") List<Long> blockedIds,
+		Pageable pageable);
+
+	@Query("SELECT j.id FROM Journal j WHERE j.member.id IN :memberIds AND j.id NOT IN :seenIds AND j.member.id NOT IN :blockedIds ORDER BY j.createdAt DESC")
+	Page<Long> findIdsByMemberIdInAndIdNotInExcludingBlocked(@Param("memberIds") List<Long> memberIds,
+		@Param("seenIds") List<Long> seenIds,
+		@Param("blockedIds") List<Long> blockedIds,
+		Pageable pageable);
+
+	@Query("SELECT COUNT(j) FROM Journal j WHERE j.member.id NOT IN :excludeMemberIds AND (:seenIds IS NULL OR j.id NOT IN :seenIds)")
+	long countAvailableJournalsForRandomFeed(@Param("excludeMemberIds") List<Long> excludeMemberIds,
+		@Param("seenIds") List<Long> seenIds);
+
+	@Query(value = """
+		SELECT j.id FROM journal j
+		WHERE j.member_id NOT IN (:memberIds)
+		ORDER BY j.random_index
+		LIMIT :limit
+		""", nativeQuery = true)
+	List<Long> findRandomIdsByMemberIdNotIn(
+		@Param("memberIds") List<Long> memberIds,
+		@Param("limit") int limit
+	);
+
+	@Modifying
+	@Query(value = "UPDATE journal SET random_index = RAND()", nativeQuery = true)
+	void updateRandomIndex();
 }

--- a/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
@@ -80,4 +80,19 @@ public interface JournalRepository extends JpaRepository<Journal, Long> {
     """, nativeQuery = true)
 	List<Long> findOptimizedRandomAll(@Param("limit") int limit);
 
+	@Query("""
+    SELECT j.id FROM Journal j
+    WHERE j.member.id = :memberId
+      AND j.region IN :regions
+      AND (:blockedIds IS NULL OR j.member.id NOT IN :blockedIds)
+    """)
+	Page<Long> findIdsByMemberIdAndRegionInExcludingBlocked(@Param("memberId") Long memberId, @Param("regions") List<String> regions, @Param("blockedIds") List<Long> blockedIds, Pageable pageable);
+
+	@Query("""
+    SELECT j.id FROM Journal j
+    WHERE j.member.id = :memberId
+      AND (:blockedIds IS NULL OR j.member.id NOT IN :blockedIds)
+    """)
+	Page<Long> findIdsByMemberIdExcludingBlocked(@Param("memberId") Long memberId, @Param("blockedIds") List<Long> blockedIds, Pageable pageable);
+
 }

--- a/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/traveljournal/domain/journal/repository/JournalRepository.java
@@ -95,4 +95,6 @@ public interface JournalRepository extends JpaRepository<Journal, Long> {
     """)
 	Page<Long> findIdsByMemberIdExcludingBlocked(@Param("memberId") Long memberId, @Param("blockedIds") List<Long> blockedIds, Pageable pageable);
 
+	@Query("SELECT j.region, COUNT(j) FROM Journal j WHERE j.member.id = :memberId GROUP BY j.region")
+	List<Object[]> countJournalsByRegion(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
+++ b/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
@@ -20,7 +20,7 @@ import com.traveljournal.domain.Image.repository.ImageInfoRepository;
 import com.traveljournal.domain.Image.service.ImageService;
 import com.traveljournal.domain.block.service.BlockService;
 import com.traveljournal.domain.hashtag.entity.HashTag;
-import com.traveljournal.domain.hashtag.repository.HashTagRepository;
+import com.traveljournal.domain.hashtag.service.HashTagService;
 import com.traveljournal.domain.journal.dto.JournalCreateRequest;
 import com.traveljournal.domain.journal.dto.JournalDayRequest;
 import com.traveljournal.domain.journal.dto.JournalDaySpotRequest;
@@ -46,7 +46,7 @@ import lombok.RequiredArgsConstructor;
 public class JournalService {
 
 	private final JournalRepository journalRepository;
-	private final HashTagRepository hashTagRepository;
+	private final HashTagService hashTagService;
 	private final ImageInfoRepository imageInfoRepository;
 	private final MemberRegionStatisticsService memberRegionStatisticsService;
 	private final ImageService imageService;
@@ -105,7 +105,7 @@ public class JournalService {
 		validateRequest(request);
 
 		Member member = memberService.findById(memberId);
-		List<HashTag> tags = getOrCreateHashTags(request.hashTag());
+		List<HashTag> tags = hashTagService.getOrCreateHashTags(request.hashTag());
 
 		Journal journal = createJournalEntity(request, member, tags);
 
@@ -135,16 +135,6 @@ public class JournalService {
 		if (request.photoMetadataList() == null) {
 			throw new BadRequestException("사진 메타데이터가 필요합니다.");
 		}
-	}
-
-	private List<HashTag> getOrCreateHashTags(List<String> tagNames) {
-		List<HashTag> tags = new ArrayList<>();
-		for (String tagName : tagNames) {
-			HashTag tag = hashTagRepository.findByTagName(tagName)
-				.orElseGet(() -> hashTagRepository.save(HashTag.of(tagName)));
-			tags.add(tag);
-		}
-		return tags;
 	}
 
 	private Journal createJournalEntity(JournalCreateRequest request, Member member, List<HashTag> tags) {

--- a/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
+++ b/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
@@ -34,6 +34,7 @@ import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.photo.dto.PhotoMetadataRequest;
 import com.traveljournal.domain.photo.entity.Photo;
 import com.traveljournal.domain.photo.repository.PhotoRepository;
+import com.traveljournal.domain.photo.service.PhotoService;
 import com.traveljournal.domain.statistics.service.MemberRegionStatisticsService;
 import com.traveljournal.domain.statistics.service.MemberStatisticsService;
 import com.traveljournal.global.exception.BadRequestException;
@@ -54,6 +55,7 @@ public class JournalService {
 	private final MemberService memberService;
 	private final BlockService blockService;
 	private final MemberStatisticsService memberStatisticsService;
+	private final PhotoService photoService;
 
 	@Transactional(readOnly = true)
 	public Page<JournalListResponse> findJournalsByRegionWithPaging(Long memberId, Long viewerId, String regionName,
@@ -187,9 +189,7 @@ public class JournalService {
 
 				ImageInfo imageInfo = imageInfoService.getImageInfo(meta.uploadId());
 
-				if (photoRepository.existsByImageInfo(imageInfo)) {
-					throw new BadRequestException("이미 등록된 사진입니다: " + meta.uploadId());
-				}
+				photoService.existsByImageInfo(imageInfo, meta.uploadId());
 
 				Photo photo = Photo.builder()
 					.description(meta.description())

--- a/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
+++ b/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.traveljournal.domain.Image.entity.ImageInfo;
 import com.traveljournal.domain.Image.repository.ImageInfoRepository;
 import com.traveljournal.domain.Image.service.ImageService;
+import com.traveljournal.domain.block.service.BlockService;
 import com.traveljournal.domain.hashtag.entity.HashTag;
 import com.traveljournal.domain.hashtag.repository.HashTagRepository;
 import com.traveljournal.domain.journal.dto.JournalCreateRequest;
@@ -48,18 +49,23 @@ public class JournalService {
 	private final ImageService imageService;
 	private final PhotoRepository photoRepository;
 	private final MemberService memberService;
+	private final BlockService blockService;
 
 	@Transactional(readOnly = true)
-	public Page<JournalListResponse> findJournalsByRegionWithPaging(Long memberId, String regionName,
+	public Page<JournalListResponse> findJournalsByRegionWithPaging(Long memberId, Long viewerId, String regionName,
 		Pageable pageable) {
 		List<String> regionList = RegionGroupUtil.getRegionList(regionName);
-		Page<Long> journalIdPage = journalRepository.findIdsByMemberIdAndRegionIn(memberId, regionList, pageable);
+		List<Long> blockedIds = blockService.getBlockedMemberIds(viewerId);
+
+		Page<Long> journalIdPage = journalRepository.findIdsByMemberIdAndRegionInExcludingBlocked(memberId, regionList, blockedIds, pageable);
 		return getJournalListResponses(pageable, journalIdPage);
 	}
 
 	@Transactional(readOnly = true)
-	public Page<JournalListResponse> findAllJournalsByMemberId(Long memberId, Pageable pageable) {
-		Page<Long> journalIdPage = journalRepository.findIdsByMemberId(memberId, pageable);
+	public Page<JournalListResponse> findAllJournalsByMemberId(Long memberId, Long viewerId, Pageable pageable) {
+
+		List<Long> blockedIds = blockService.getBlockedMemberIds(viewerId);
+		Page<Long> journalIdPage = journalRepository.findIdsByMemberIdExcludingBlocked(memberId, blockedIds, pageable);
 		return getJournalListResponses(pageable, journalIdPage);
 	}
 

--- a/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
+++ b/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
@@ -34,14 +34,10 @@ import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.photo.dto.PhotoMetadataRequest;
 import com.traveljournal.domain.photo.entity.Photo;
 import com.traveljournal.domain.photo.repository.PhotoRepository;
-import com.traveljournal.domain.statistics.entity.MemberRegionStatistics;
-import com.traveljournal.domain.statistics.entity.MemberRegionStatisticsId;
-import com.traveljournal.domain.statistics.entity.MemberStatistics;
-import com.traveljournal.domain.statistics.repository.MemberRegionStatisticsRepository;
-import com.traveljournal.domain.statistics.repository.MemberStatisticsRepository;
+import com.traveljournal.domain.statistics.service.MemberRegionStatisticsService;
+import com.traveljournal.domain.statistics.service.MemberStatisticsService;
 import com.traveljournal.global.exception.BadRequestException;
 import com.traveljournal.global.util.RegionGroupUtil;
-import com.traveljournal.global.util.RegionNormalizer;
 
 import lombok.RequiredArgsConstructor;
 
@@ -52,12 +48,12 @@ public class JournalService {
 	private final JournalRepository journalRepository;
 	private final HashTagRepository hashTagRepository;
 	private final ImageInfoRepository imageInfoRepository;
-	private final MemberStatisticsRepository memberStatisticsRepository;
-	private final MemberRegionStatisticsRepository memberRegionStatisticsRepository;
+	private final MemberRegionStatisticsService memberRegionStatisticsService;
 	private final ImageService imageService;
 	private final PhotoRepository photoRepository;
 	private final MemberService memberService;
 	private final BlockService blockService;
+	private final MemberStatisticsService memberStatisticsService;
 
 	@Transactional(readOnly = true)
 	public Page<JournalListResponse> findJournalsByRegionWithPaging(Long memberId, Long viewerId, String regionName,
@@ -121,20 +117,9 @@ public class JournalService {
 
 		journalRepository.save(journal);
 
-		MemberStatistics stats = memberStatisticsRepository.findById(memberId)
-			.orElseThrow(() -> new IllegalArgumentException("통계 정보 없음"));
-		stats.increaseTravelDiaryCount();
+		memberStatisticsService.increaseTravelDiaryCount(memberId);
 
-		String rawRegion = journal.getRegion();
-		String regionGroup = RegionNormalizer.normalize(rawRegion);
-		MemberRegionStatisticsId regionStatsId = new MemberRegionStatisticsId(memberId, regionGroup);
-
-		MemberRegionStatistics regionStats = memberRegionStatisticsRepository.findById(regionStatsId)
-			.orElseGet(() -> {
-				MemberRegionStatistics newStats = new MemberRegionStatistics(regionStatsId, 0L, 0L);
-				return memberRegionStatisticsRepository.save(newStats);
-			});
-		regionStats.increaseTravelDiaryCount();
+		memberRegionStatisticsService.increaseTravelDiaryCount(memberId, journal.getRegion());
 
 		return journal.getId();
 	}

--- a/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
+++ b/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.traveljournal.domain.Image.entity.ImageInfo;
-import com.traveljournal.domain.Image.repository.ImageInfoRepository;
+import com.traveljournal.domain.Image.service.ImageInfoService;
 import com.traveljournal.domain.Image.service.ImageService;
 import com.traveljournal.domain.block.service.BlockService;
 import com.traveljournal.domain.hashtag.entity.HashTag;
@@ -47,7 +47,7 @@ public class JournalService {
 
 	private final JournalRepository journalRepository;
 	private final HashTagService hashTagService;
-	private final ImageInfoRepository imageInfoRepository;
+	private final ImageInfoService imageInfoService;
 	private final MemberRegionStatisticsService memberRegionStatisticsService;
 	private final ImageService imageService;
 	private final PhotoRepository photoRepository;
@@ -185,8 +185,7 @@ public class JournalService {
 				if (!uniqueUploadIds.add(meta.uploadId()))
 					continue;
 
-				ImageInfo imageInfo = imageInfoRepository.findByFilename(meta.uploadId())
-					.orElseThrow(() -> new BadRequestException("이미지 정보가 없습니다: " + meta.uploadId()));
+				ImageInfo imageInfo = imageInfoService.getImageInfo(meta.uploadId());
 
 				if (photoRepository.existsByImageInfo(imageInfo)) {
 					throw new BadRequestException("이미 등록된 사진입니다: " + meta.uploadId());

--- a/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
+++ b/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
@@ -31,13 +31,17 @@ import com.traveljournal.domain.journal.entity.JournalDaySpot;
 import com.traveljournal.domain.journal.repository.JournalRepository;
 import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.member.service.MemberService;
-import com.traveljournal.domain.statistics.entity.MemberStatistics;
-import com.traveljournal.domain.statistics.repository.MemberStatisticsRepository;
 import com.traveljournal.domain.photo.dto.PhotoMetadataRequest;
 import com.traveljournal.domain.photo.entity.Photo;
 import com.traveljournal.domain.photo.repository.PhotoRepository;
+import com.traveljournal.domain.statistics.entity.MemberRegionStatistics;
+import com.traveljournal.domain.statistics.entity.MemberRegionStatisticsId;
+import com.traveljournal.domain.statistics.entity.MemberStatistics;
+import com.traveljournal.domain.statistics.repository.MemberRegionStatisticsRepository;
+import com.traveljournal.domain.statistics.repository.MemberStatisticsRepository;
 import com.traveljournal.global.exception.BadRequestException;
 import com.traveljournal.global.util.RegionGroupUtil;
+import com.traveljournal.global.util.RegionNormalizer;
 
 import lombok.RequiredArgsConstructor;
 
@@ -49,6 +53,7 @@ public class JournalService {
 	private final HashTagRepository hashTagRepository;
 	private final ImageInfoRepository imageInfoRepository;
 	private final MemberStatisticsRepository memberStatisticsRepository;
+	private final MemberRegionStatisticsRepository memberRegionStatisticsRepository;
 	private final ImageService imageService;
 	private final PhotoRepository photoRepository;
 	private final MemberService memberService;
@@ -119,6 +124,17 @@ public class JournalService {
 		MemberStatistics stats = memberStatisticsRepository.findById(memberId)
 			.orElseThrow(() -> new IllegalArgumentException("통계 정보 없음"));
 		stats.increaseTravelDiaryCount();
+
+		String rawRegion = journal.getRegion();
+		String regionGroup = RegionNormalizer.normalize(rawRegion);
+		MemberRegionStatisticsId regionStatsId = new MemberRegionStatisticsId(memberId, regionGroup);
+
+		MemberRegionStatistics regionStats = memberRegionStatisticsRepository.findById(regionStatsId)
+			.orElseGet(() -> {
+				MemberRegionStatistics newStats = new MemberRegionStatistics(regionStatsId, 0L, 0L);
+				return memberRegionStatisticsRepository.save(newStats);
+			});
+		regionStats.increaseTravelDiaryCount();
 
 		return journal.getId();
 	}

--- a/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
+++ b/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
@@ -54,6 +54,8 @@ public class JournalService {
 	@Transactional(readOnly = true)
 	public Page<JournalListResponse> findJournalsByRegionWithPaging(Long memberId, Long viewerId, String regionName,
 		Pageable pageable) {
+		blockService.validateNotBlocked(viewerId, memberId);
+
 		List<String> regionList = RegionGroupUtil.getRegionList(regionName);
 		List<Long> blockedIds = blockService.getBlockedMemberIds(viewerId);
 
@@ -63,6 +65,7 @@ public class JournalService {
 
 	@Transactional(readOnly = true)
 	public Page<JournalListResponse> findAllJournalsByMemberId(Long memberId, Long viewerId, Pageable pageable) {
+		blockService.validateNotBlocked(viewerId, memberId);
 
 		List<Long> blockedIds = blockService.getBlockedMemberIds(viewerId);
 		Page<Long> journalIdPage = journalRepository.findIdsByMemberIdExcludingBlocked(memberId, blockedIds, pageable);

--- a/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
+++ b/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
@@ -33,7 +33,6 @@ import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.photo.dto.PhotoMetadataRequest;
 import com.traveljournal.domain.photo.entity.Photo;
-import com.traveljournal.domain.photo.repository.PhotoRepository;
 import com.traveljournal.domain.photo.service.PhotoService;
 import com.traveljournal.domain.statistics.service.MemberRegionStatisticsService;
 import com.traveljournal.domain.statistics.service.MemberStatisticsService;
@@ -51,7 +50,6 @@ public class JournalService {
 	private final ImageInfoService imageInfoService;
 	private final MemberRegionStatisticsService memberRegionStatisticsService;
 	private final ImageService imageService;
-	private final PhotoRepository photoRepository;
 	private final MemberService memberService;
 	private final BlockService blockService;
 	private final MemberStatisticsService memberStatisticsService;

--- a/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
+++ b/src/main/java/com/traveljournal/domain/journal/service/JournalService.java
@@ -31,6 +31,8 @@ import com.traveljournal.domain.journal.entity.JournalDaySpot;
 import com.traveljournal.domain.journal.repository.JournalRepository;
 import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.member.service.MemberService;
+import com.traveljournal.domain.statistics.entity.MemberStatistics;
+import com.traveljournal.domain.statistics.repository.MemberStatisticsRepository;
 import com.traveljournal.domain.photo.dto.PhotoMetadataRequest;
 import com.traveljournal.domain.photo.entity.Photo;
 import com.traveljournal.domain.photo.repository.PhotoRepository;
@@ -46,6 +48,7 @@ public class JournalService {
 	private final JournalRepository journalRepository;
 	private final HashTagRepository hashTagRepository;
 	private final ImageInfoRepository imageInfoRepository;
+	private final MemberStatisticsRepository memberStatisticsRepository;
 	private final ImageService imageService;
 	private final PhotoRepository photoRepository;
 	private final MemberService memberService;
@@ -112,6 +115,11 @@ public class JournalService {
 		setThumbnailUrl(journal, journalDays);
 
 		journalRepository.save(journal);
+
+		MemberStatistics stats = memberStatisticsRepository.findById(memberId)
+			.orElseThrow(() -> new IllegalArgumentException("통계 정보 없음"));
+		stats.increaseTravelDiaryCount();
+
 		return journal.getId();
 	}
 

--- a/src/main/java/com/traveljournal/domain/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/traveljournal/domain/member/dto/MemberProfileResponse.java
@@ -2,6 +2,7 @@ package com.traveljournal.domain.member.dto;
 
 import com.traveljournal.domain.member.entity.AccountScope;
 import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.statistics.entity.MemberStatistics;
 
 import lombok.Builder;
 
@@ -17,16 +18,16 @@ public record MemberProfileResponse (
 	Boolean isFirstLogin
 ) {
 
-	public static MemberProfileResponse of(Member member) {
+	public static MemberProfileResponse of(Member member, MemberStatistics memberStatistics) {
 		return MemberProfileResponse.builder()
 			.nickname(member.getNickname())
 			.profileImageUrl(member.getProfileImageUrl())
 			.accountScope(member.getAccountScope())
-			.followerCount(363L)
-			.followingCount(180L)
-			.travelDiaryCount(36L)
-			.placesCount(88L)
+			.followerCount(memberStatistics.getFollowerCount())
+			.followingCount(memberStatistics.getFollowingCount())
+			.travelDiaryCount(memberStatistics.getTravelDiaryCount())
+			.placesCount(memberStatistics.getPlacesCount())
 			.isFirstLogin(member.getIsFirstLogin())
 			.build();
-	}// 임시로 멤버만 들어가 있습니다. 팔로워, 여행일지, 지역시 추가해야합니다
+	}
 }

--- a/src/main/java/com/traveljournal/domain/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/traveljournal/domain/member/dto/MemberProfileResponse.java
@@ -1,5 +1,6 @@
 package com.traveljournal.domain.member.dto;
 
+import com.traveljournal.domain.block.dto.BlockRelationType;
 import com.traveljournal.domain.member.entity.AccountScope;
 import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.statistics.entity.MemberStatistics;
@@ -15,7 +16,8 @@ public record MemberProfileResponse (
 	Long followerCount,
 	Long travelDiaryCount,
 	Long placesCount,
-	Boolean isFirstLogin
+	Boolean isFirstLogin,
+	BlockRelationType blockRelationType
 ) {
 
 	public static MemberProfileResponse of(Member member, MemberStatistics memberStatistics) {
@@ -28,6 +30,20 @@ public record MemberProfileResponse (
 			.travelDiaryCount(memberStatistics.getTravelDiaryCount())
 			.placesCount(memberStatistics.getPlacesCount())
 			.isFirstLogin(member.getIsFirstLogin())
+			.build();
+	}
+
+	public static MemberProfileResponse of(Member member, MemberStatistics memberStatistics, BlockRelationType blockRelationType) {
+		return MemberProfileResponse.builder()
+			.nickname(member.getNickname())
+			.profileImageUrl(member.getProfileImageUrl())
+			.accountScope(member.getAccountScope())
+			.followerCount(memberStatistics.getFollowerCount())
+			.followingCount(memberStatistics.getFollowingCount())
+			.travelDiaryCount(memberStatistics.getTravelDiaryCount())
+			.placesCount(memberStatistics.getPlacesCount())
+			.isFirstLogin(member.getIsFirstLogin())
+			.blockRelationType(blockRelationType)
 			.build();
 	}
 }

--- a/src/main/java/com/traveljournal/domain/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/traveljournal/domain/member/dto/MemberProfileResponse.java
@@ -5,18 +5,28 @@ import com.traveljournal.domain.member.entity.AccountScope;
 import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.statistics.entity.MemberStatistics;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record MemberProfileResponse (
+	@Schema(example = "도요새")
 	String nickname,
+	@Schema(example = "https://travel-journal-s3.s3.amazonaws.com/default/profile/default1.png")
 	String profileImageUrl,
+	@Schema(example = "PUBLIC")
 	AccountScope accountScope,
+	@Schema(example = "1")
 	Long followingCount,
+	@Schema(example = "12")
 	Long followerCount,
+	@Schema(example = "53")
 	Long travelDiaryCount,
+	@Schema(example = "0")
 	Long placesCount,
+	@Schema(example = "false")
 	Boolean isFirstLogin,
+	@Schema(allowableValues = {"NONE", "BLOCKED_BY_ME", "BLOCKED_ME", "MUTUAL_BLOCK"})
 	BlockRelationType blockRelationType
 ) {
 

--- a/src/main/java/com/traveljournal/domain/member/service/MemberService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/MemberService.java
@@ -17,6 +17,8 @@ import com.traveljournal.domain.member.entity.SocialProvider;
 import com.traveljournal.domain.member.repository.MemberRepository;
 import com.traveljournal.domain.member.repository.SocialTokenRepository;
 import com.traveljournal.domain.member.repository.TokenRepository;
+import com.traveljournal.domain.statistics.entity.MemberStatistics;
+import com.traveljournal.domain.statistics.repository.MemberStatisticsRepository;
 import com.traveljournal.global.exception.MemberDeleteException;
 import com.traveljournal.global.exception.ResourceNotFoundException;
 
@@ -36,6 +38,7 @@ public class MemberService {
 	private final ImageService imageService;
 	private final TokenRepository tokenRepository;
 	private final SocialTokenRepository socialTokenRepository;
+	private final MemberStatisticsRepository memberStatisticsRepository;
 
 	@PersistenceContext
 	private EntityManager entityManager;
@@ -72,7 +75,18 @@ public class MemberService {
 
 		Member newMember = createNewMember(socialMemberInfo, socialProvider);
 
-		return memberRepository.save(newMember);
+		Member savedMember = memberRepository.save(newMember);
+
+		MemberStatistics stats = new MemberStatistics(
+			savedMember.getId(),
+			0L,
+			0L,
+			0L,
+			0L
+		);
+		memberStatisticsRepository.save(stats);
+
+		return savedMember;
 	}
 
 	public Member createNewMember(SocialMemberInfo socialMemberInfo, SocialProvider socialProvider) {
@@ -157,8 +171,10 @@ public class MemberService {
 	public MemberProfileResponse getMemberProfile(Long memberId) {
 
 		Member member = findById(memberId);
+		MemberStatistics stats = memberStatisticsRepository.findById(memberId)
+			.orElseThrow(() -> new IllegalArgumentException("통계 정보 없음"));
 
-		return MemberProfileResponse.of(member);
+		return MemberProfileResponse.of(member, stats);
 	}
 
 	@Transactional

--- a/src/main/java/com/traveljournal/domain/member/service/MemberService.java
+++ b/src/main/java/com/traveljournal/domain/member/service/MemberService.java
@@ -9,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.traveljournal.domain.Image.service.ImageService;
 import com.traveljournal.domain.auth.dto.SocialMemberInfo;
+import com.traveljournal.domain.block.dto.BlockRelationType;
 import com.traveljournal.domain.member.dto.MemberProfileResponse;
 import com.traveljournal.domain.member.dto.ProfileRequest;
 import com.traveljournal.domain.member.entity.AccountScope;
@@ -171,10 +172,15 @@ public class MemberService {
 	public MemberProfileResponse getMemberProfile(Long memberId) {
 
 		Member member = findById(memberId);
-		MemberStatistics stats = memberStatisticsRepository.findById(memberId)
-			.orElseThrow(() -> new IllegalArgumentException("통계 정보 없음"));
+		MemberStatistics stats = getMemberStatistics(memberId);
 
-		return MemberProfileResponse.of(member, stats);
+		return MemberProfileResponse.of(member, stats, BlockRelationType.NONE);
+	}
+
+	@Transactional(readOnly = true)
+	public MemberStatistics getMemberStatistics(Long memberId) {
+		return memberStatisticsRepository.findById(memberId)
+			.orElseThrow(() -> new IllegalArgumentException("통계 정보 없음"));
 	}
 
 	@Transactional

--- a/src/main/java/com/traveljournal/domain/memberDashboard/controller/MemberDashboardController.java
+++ b/src/main/java/com/traveljournal/domain/memberDashboard/controller/MemberDashboardController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.traveljournal.domain.memberDashboard.dto.MemberDashbordResponse;
 import com.traveljournal.domain.memberDashboard.service.MemberDashboardService;
 import com.traveljournal.global.data.ApiResponseHandler;
+import com.traveljournal.global.security.util.SecurityUtil;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -30,8 +31,9 @@ public class MemberDashboardController {
 	)
 	public ResponseEntity<MemberDashbordResponse> getMemberDashborad(
 		@PathVariable("memberId") Long memberId) {
+		Long currentMemberId = SecurityUtil.getCurrentMemberId();
 
-		MemberDashbordResponse memberDashbordResponse = memberDashboardService.getMemberDashbord(memberId);
+		MemberDashbordResponse memberDashbordResponse = memberDashboardService.getMemberDashbord(memberId, currentMemberId);
 
 		return ApiResponseHandler.getObjectSuccess(memberDashbordResponse);
 	}

--- a/src/main/java/com/traveljournal/domain/memberDashboard/dto/RegionInfo.java
+++ b/src/main/java/com/traveljournal/domain/memberDashboard/dto/RegionInfo.java
@@ -1,8 +1,18 @@
 package com.traveljournal.domain.memberDashboard.dto;
 
+import lombok.Builder;
+
+@Builder
 public record RegionInfo(
 	String regionName,
 	Long travelDiaryCount,
 	Long placesCount
 ) {
+	public static RegionInfo of(String regionName, Long travelDiaryCount, Long placesCount) {
+		return RegionInfo.builder()
+			.regionName(regionName)
+			.travelDiaryCount(travelDiaryCount)
+			.placesCount(placesCount)
+			.build();
+	}
 }

--- a/src/main/java/com/traveljournal/domain/memberDashboard/dto/RegionInfo.java
+++ b/src/main/java/com/traveljournal/domain/memberDashboard/dto/RegionInfo.java
@@ -1,18 +1,11 @@
 package com.traveljournal.domain.memberDashboard.dto;
 
-import lombok.Builder;
-
-@Builder
 public record RegionInfo(
 	String regionName,
 	Long travelDiaryCount,
 	Long placesCount
 ) {
 	public static RegionInfo of(String regionName, Long travelDiaryCount, Long placesCount) {
-		return RegionInfo.builder()
-			.regionName(regionName)
-			.travelDiaryCount(travelDiaryCount)
-			.placesCount(placesCount)
-			.build();
+		return new RegionInfo(regionName, travelDiaryCount, placesCount);
 	}
 }

--- a/src/main/java/com/traveljournal/domain/memberDashboard/service/MemberDashboardService.java
+++ b/src/main/java/com/traveljournal/domain/memberDashboard/service/MemberDashboardService.java
@@ -1,14 +1,19 @@
 package com.traveljournal.domain.memberDashboard.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
 import com.traveljournal.domain.block.service.BlockService;
+import com.traveljournal.domain.journal.repository.JournalRepository;
 import com.traveljournal.domain.member.dto.MemberProfileResponse;
 import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.memberDashboard.dto.MemberDashbordResponse;
 import com.traveljournal.domain.memberDashboard.dto.RegionInfo;
+import com.traveljournal.domain.place.repository.PlaceRepository;
+import com.traveljournal.global.util.RegionGroupUtil;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +25,8 @@ public class MemberDashboardService {
 
 	private final MemberService memberService;
 	private final BlockService blockService;
+	private final PlaceRepository placeRepository;
+	private final JournalRepository journalRepository;
 
 	public MemberDashbordResponse getMemberDashbord(Long memberId, Long viewerId) {
 
@@ -27,20 +34,40 @@ public class MemberDashboardService {
 
 		MemberProfileResponse memberProfileResponse = memberService.getMemberProfile(memberId);
 
-		List<RegionInfo> regionInfos = getRegionInfoList();
+		List<RegionInfo> regionInfos = getRegionInfoList(memberId);
 
 		return new MemberDashbordResponse(memberProfileResponse, regionInfos);
 	}
 
-	public List<RegionInfo> getRegionInfoList() {
+	public List<RegionInfo> getRegionInfoList(Long memberId) {
+		List<Object[]> placeRegionCounts = placeRepository.countPlacesByRegion(memberId);
+		List<Object[]> journalRegionCounts = journalRepository.countJournalsByRegion(memberId);
 
-		return List.of(
-			new RegionInfo("수도권", 57L, 88L),
-			new RegionInfo("강원도", 377L, 444L),
-			new RegionInfo("충청도", 21L, 5L),
-			new RegionInfo("경상도", 97L, 70L),
-			new RegionInfo("전라도", 157L, 665L),
-			new RegionInfo("제주도", 999L, 1005L)
-		);
+		Map<String, Long> placeRegionCountMap = placeRegionCounts.stream()
+			.collect(Collectors.toMap(
+				obj -> (String) obj[0],
+				obj -> (Long) obj[1]
+			));
+
+		Map<String, Long> journalRegionCountMap = journalRegionCounts.stream()
+			.collect(Collectors.toMap(
+				obj -> (String) obj[0],
+				obj -> (Long) obj[1]
+			));
+
+		return RegionGroupUtil.REGION_GROUP_MAP.keySet().stream()
+			.map(group -> {
+				List<String> regionList = RegionGroupUtil.getRegionList(group);
+				long placeCount = sumRegionCount(regionList, placeRegionCountMap);
+				long journalCount = sumRegionCount(regionList, journalRegionCountMap);
+				return RegionInfo.of(group, journalCount, placeCount);
+			})
+			.toList();
+	}
+
+	private long sumRegionCount(List<String> regionList, Map<String, Long> countMap) {
+		return regionList.stream()
+			.mapToLong(region -> countMap.getOrDefault(region, 0L))
+			.sum();
 	}
 }

--- a/src/main/java/com/traveljournal/domain/memberDashboard/service/MemberDashboardService.java
+++ b/src/main/java/com/traveljournal/domain/memberDashboard/service/MemberDashboardService.java
@@ -4,9 +4,10 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.traveljournal.domain.block.service.BlockService;
+import com.traveljournal.domain.member.dto.MemberProfileResponse;
 import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.memberDashboard.dto.MemberDashbordResponse;
-import com.traveljournal.domain.member.dto.MemberProfileResponse;
 import com.traveljournal.domain.memberDashboard.dto.RegionInfo;
 
 import lombok.RequiredArgsConstructor;
@@ -18,8 +19,11 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberDashboardService {
 
 	private final MemberService memberService;
+	private final BlockService blockService;
 
-	public MemberDashbordResponse getMemberDashbord(Long memberId) {
+	public MemberDashbordResponse getMemberDashbord(Long memberId, Long viewerId) {
+
+		blockService.validateNotBlocked(viewerId, memberId);
 
 		MemberProfileResponse memberProfileResponse = memberService.getMemberProfile(memberId);
 

--- a/src/main/java/com/traveljournal/domain/memberDashboard/service/MemberDashboardService.java
+++ b/src/main/java/com/traveljournal/domain/memberDashboard/service/MemberDashboardService.java
@@ -7,14 +7,17 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.traveljournal.domain.block.dto.BlockRelationType;
 import com.traveljournal.domain.block.service.BlockService;
 import com.traveljournal.domain.journal.repository.JournalRepository;
 import com.traveljournal.domain.member.dto.MemberProfileResponse;
+import com.traveljournal.domain.member.entity.Member;
 import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.memberDashboard.dto.MemberDashbordResponse;
 import com.traveljournal.domain.memberDashboard.dto.RegionInfo;
 import com.traveljournal.domain.place.repository.PlaceRepository;
 import com.traveljournal.domain.statistics.entity.MemberRegionStatistics;
+import com.traveljournal.domain.statistics.entity.MemberStatistics;
 import com.traveljournal.domain.statistics.repository.MemberRegionStatisticsRepository;
 import com.traveljournal.global.util.RegionGroupUtil;
 
@@ -34,9 +37,13 @@ public class MemberDashboardService {
 
 	public MemberDashbordResponse getMemberDashbord(Long memberId, Long viewerId) {
 
-		blockService.validateNotBlocked(viewerId, memberId);
+		Member member = memberService.findById(memberId);
 
-		MemberProfileResponse memberProfileResponse = memberService.getMemberProfile(memberId);
+		MemberStatistics memberStatistics = memberService.getMemberStatistics(memberId);
+
+		BlockRelationType blockRelationType = blockService.getBlockRelation(viewerId, memberId);
+
+		MemberProfileResponse memberProfileResponse = MemberProfileResponse.of(member, memberStatistics, blockRelationType);
 
 		List<RegionInfo> regionInfos = getRegionStatistics(memberId);
 

--- a/src/main/java/com/traveljournal/domain/memberDashboard/service/MemberDashboardService.java
+++ b/src/main/java/com/traveljournal/domain/memberDashboard/service/MemberDashboardService.java
@@ -2,6 +2,7 @@ package com.traveljournal.domain.memberDashboard.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -13,6 +14,8 @@ import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.memberDashboard.dto.MemberDashbordResponse;
 import com.traveljournal.domain.memberDashboard.dto.RegionInfo;
 import com.traveljournal.domain.place.repository.PlaceRepository;
+import com.traveljournal.domain.statistics.entity.MemberRegionStatistics;
+import com.traveljournal.domain.statistics.repository.MemberRegionStatisticsRepository;
 import com.traveljournal.global.util.RegionGroupUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +30,7 @@ public class MemberDashboardService {
 	private final BlockService blockService;
 	private final PlaceRepository placeRepository;
 	private final JournalRepository journalRepository;
+	private final MemberRegionStatisticsRepository memberRegionStatisticsRepository;
 
 	public MemberDashbordResponse getMemberDashbord(Long memberId, Long viewerId) {
 
@@ -34,11 +38,40 @@ public class MemberDashboardService {
 
 		MemberProfileResponse memberProfileResponse = memberService.getMemberProfile(memberId);
 
-		List<RegionInfo> regionInfos = getRegionInfoList(memberId);
+		List<RegionInfo> regionInfos = getRegionStatistics(memberId);
 
 		return new MemberDashbordResponse(memberProfileResponse, regionInfos);
 	}
 
+	public List<RegionInfo> getRegionStatistics (Long memberId) {
+
+		List<MemberRegionStatistics> statsList = memberRegionStatisticsRepository.findAllByIdMemberId(memberId);
+
+		Map<String, MemberRegionStatistics> statsMap = statsList.stream()
+			.collect(Collectors.toMap(
+				s -> s.getId().getRegionGroup(),
+				s -> s
+			));
+
+		return RegionGroupUtil.REGION_GROUP_MAP.keySet().stream()
+			.map(group -> {
+				List<String> regionList = RegionGroupUtil.getRegionList(group);
+				long travelDiaryCount = regionList.stream()
+					.map(statsMap::get)
+					.filter(Objects::nonNull)
+					.mapToLong(MemberRegionStatistics::getTravelDiaryCount)
+					.sum();
+				long placesCount = regionList.stream()
+					.map(statsMap::get)
+					.filter(Objects::nonNull)
+					.mapToLong(MemberRegionStatistics::getPlacesCount)
+					.sum();
+				return RegionInfo.of(group, travelDiaryCount, placesCount);
+			})
+			.toList();
+	}
+
+	//직접 계산 - 추후 필요할 수 있기에 남겨둡니다.
 	public List<RegionInfo> getRegionInfoList(Long memberId) {
 		List<Object[]> placeRegionCounts = placeRepository.countPlacesByRegion(memberId);
 		List<Object[]> journalRegionCounts = journalRepository.countJournalsByRegion(memberId);

--- a/src/main/java/com/traveljournal/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/traveljournal/domain/photo/service/PhotoService.java
@@ -8,9 +8,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.traveljournal.domain.Image.entity.ImageInfo;
 import com.traveljournal.domain.Image.service.ImageService;
 import com.traveljournal.domain.Image.util.FilenameUtil;
 import com.traveljournal.domain.photo.dto.PhotoUploadResponse;
+import com.traveljournal.domain.photo.repository.PhotoRepository;
+import com.traveljournal.global.exception.BadRequestException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PhotoService {
 	private final ImageService imageService;
+	private final PhotoRepository photoRepository;
 
 	@Transactional
 	public PhotoUploadResponse uploadJournalPhoto(MultipartFile photoFile, Long memberId) {
@@ -49,4 +53,11 @@ public class PhotoService {
 		}
 		return photoUploadResponses;
 	}
+
+	public void existsByImageInfo(ImageInfo imageInfo, String filename) {
+		if (photoRepository.existsByImageInfo(imageInfo)) {
+			throw new BadRequestException("이미 등록된 사진입니다: " + filename);
+		}
+	}
+
 }

--- a/src/main/java/com/traveljournal/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/traveljournal/domain/place/controller/PlaceController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.traveljournal.domain.place.dto.PlaceListResponse;
 import com.traveljournal.domain.place.service.PlaceService;
 import com.traveljournal.global.data.ApiResponseHandler;
+import com.traveljournal.global.security.util.SecurityUtil;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -40,7 +41,8 @@ public class PlaceController {
 		@Parameter(description = "수도권, 강원도, 충정도, 경상도, 전라도, 제주도")
 		@PathVariable String regionName,
 		@ParameterObject @PageableDefault Pageable pageable) {
-		return ApiResponseHandler.getObjectSuccess(placeService.findPlacesByRegionWithPaging(memberId, regionName, pageable));
+		Long currentMemberId = SecurityUtil.getCurrentMemberId();
+		return ApiResponseHandler.getObjectSuccess(placeService.findPlacesByRegionWithPaging(memberId, currentMemberId, regionName, pageable));
 	}
 
 	@Operation(
@@ -53,6 +55,7 @@ public class PlaceController {
 		@Parameter(description = "조회할 member_id")
 		@PathVariable Long memberId,
 		@ParameterObject @PageableDefault Pageable pageable) {
-		return ApiResponseHandler.getObjectSuccess(placeService.findAllPlacesByMemberId(memberId, pageable));
+		Long currentMemberId = SecurityUtil.getCurrentMemberId();
+		return ApiResponseHandler.getObjectSuccess(placeService.findAllPlacesByMemberId(memberId, currentMemberId, pageable));
 	}
 }

--- a/src/main/java/com/traveljournal/domain/place/dto/PlaceListResponse.java
+++ b/src/main/java/com/traveljournal/domain/place/dto/PlaceListResponse.java
@@ -1,7 +1,11 @@
 package com.traveljournal.domain.place.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
+import com.traveljournal.domain.place.entity.Place;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
 public record PlaceListResponse(
 	@Schema(example = "1")
 	Long placeId,
@@ -12,4 +16,13 @@ public record PlaceListResponse(
 	@Schema(example = "https://search.pstatic.net/common/?src=http%3A%2F%2Fblogfiles.naver.net%2FMjAyNTAzMjFfMTEw%2FMDAxNzQyNTU5MjY0OTkz.US8DxCfatYon23fMlPjPlqGIvpK8Zd8SIP3BuNFyGmUg.LUZS2bZBQ1aJuHyVI52EjhzHykDFewCj4mpJCeoV0G0g.JPEG%2F2025%25BA%25A2%25B2%25C9%25B0%25B3%25C8%25AD%25BD%25C3%25B1%25E2IMG_2503-009.JPG&type=sc960_832")
 	String thumbnailUrl
 ) {
+
+	public static PlaceListResponse of(Place place) {
+		return PlaceListResponse.builder()
+			.placeId(place.getId())
+			.title(place.getTitle())
+			.region(place.getRegion())
+			.thumbnailUrl(place.getThumbnailUrl())
+			.build();
+	}
 }

--- a/src/main/java/com/traveljournal/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/traveljournal/domain/place/repository/PlaceRepository.java
@@ -32,4 +32,20 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 		FROM Place p
 		WHERE (p.title LIKE %:keyword% OR p.region LIKE %:keyword%) AND p.member.id NOT IN :blockedMemberIds""")
 	Page<Long> findIdsByKeywordExcludingBlockedMembers(@Param("keyword") String keyword,@Param("blockedMemberIds") List<Long> blockedMemberIds, Pageable pageable);
+
+	@Query("""
+    SELECT j.id FROM Journal j
+    WHERE j.member.id = :memberId
+      AND j.region IN :regions
+      AND (:blockedIds IS NULL OR j.member.id NOT IN :blockedIds)
+    """)
+	Page<Long> findIdsByMemberIdAndRegionInExcludingBlocked(@Param("memberId") Long memberId, @Param("regions") List<String> regions, @Param("blockedIds") List<Long> blockedIds, Pageable pageable);
+
+	@Query("""
+    SELECT j.id FROM Journal j
+    WHERE j.member.id = :memberId
+      AND (:blockedIds IS NULL OR j.member.id NOT IN :blockedIds)
+    """)
+	Page<Long> findIdsByMemberIdExcludingBlocked(@Param("memberId") Long memberId, @Param("blockedIds") List<Long> blockedIds, Pageable pageable);
+
 }

--- a/src/main/java/com/traveljournal/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/traveljournal/domain/place/repository/PlaceRepository.java
@@ -48,4 +48,6 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     """)
 	Page<Long> findIdsByMemberIdExcludingBlocked(@Param("memberId") Long memberId, @Param("blockedIds") List<Long> blockedIds, Pageable pageable);
 
+	@Query("SELECT p.region, COUNT(p) FROM Place p WHERE p.member.id = :memberId GROUP BY p.region")
+	List<Object[]> countPlacesByRegion(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/traveljournal/domain/place/service/PlaceService.java
+++ b/src/main/java/com/traveljournal/domain/place/service/PlaceService.java
@@ -10,8 +10,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.traveljournal.domain.block.repository.BlockRepository;
 import com.traveljournal.domain.block.service.BlockService;
-import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.place.dto.PlaceListResponse;
 import com.traveljournal.domain.place.entity.Place;
 import com.traveljournal.domain.place.repository.PlaceRepository;
@@ -24,13 +24,16 @@ import lombok.RequiredArgsConstructor;
 public class PlaceService {
 
 	private final PlaceRepository placeRepository;
-	private final MemberService memberService;
+	private final BlockRepository blockRepository;
 	private final BlockService blockService;
 
 	@Transactional(readOnly = true)
 	public Page<PlaceListResponse> findPlacesByRegionWithPaging(Long memberId, Long viewerId, String regionName, Pageable pageable) {
 
+		blockService.validateNotBlocked(viewerId, memberId);
+
 		List<String> regionList = RegionGroupUtil.getRegionList(regionName);
+
 		List<Long> blockedIds = blockService.getBlockedMemberIds(viewerId);
 
 		Page<Long> placeIdPage = placeRepository.findIdsByMemberIdAndRegionInExcludingBlocked(memberId, regionList, blockedIds, pageable);
@@ -39,6 +42,8 @@ public class PlaceService {
 
 	@Transactional(readOnly = true)
 	public Page<PlaceListResponse> findAllPlacesByMemberId(Long memberId, Long viewerId, Pageable pageable) {
+
+		blockService.validateNotBlocked(viewerId, memberId);
 
 		List<Long> blockedIds = blockService.getBlockedMemberIds(viewerId);
 		Page<Long> placeIdPage = placeRepository.findIdsByMemberIdExcludingBlocked(memberId, blockedIds, pageable);

--- a/src/main/java/com/traveljournal/domain/place/service/PlaceService.java
+++ b/src/main/java/com/traveljournal/domain/place/service/PlaceService.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.traveljournal.domain.block.service.BlockService;
+import com.traveljournal.domain.member.service.MemberService;
 import com.traveljournal.domain.place.dto.PlaceListResponse;
 import com.traveljournal.domain.place.entity.Place;
 import com.traveljournal.domain.place.repository.PlaceRepository;
@@ -22,18 +24,24 @@ import lombok.RequiredArgsConstructor;
 public class PlaceService {
 
 	private final PlaceRepository placeRepository;
+	private final MemberService memberService;
+	private final BlockService blockService;
 
 	@Transactional(readOnly = true)
-	public Page<PlaceListResponse> findPlacesByRegionWithPaging(Long memberId, String regionName, Pageable pageable) {
-		List<String> regionList = RegionGroupUtil.getRegionList(regionName);
+	public Page<PlaceListResponse> findPlacesByRegionWithPaging(Long memberId, Long viewerId, String regionName, Pageable pageable) {
 
-		Page<Long> placeIdPage = placeRepository.findIdsByMemberIdAndRegionIn(memberId, regionList, pageable);
+		List<String> regionList = RegionGroupUtil.getRegionList(regionName);
+		List<Long> blockedIds = blockService.getBlockedMemberIds(viewerId);
+
+		Page<Long> placeIdPage = placeRepository.findIdsByMemberIdAndRegionInExcludingBlocked(memberId, regionList, blockedIds, pageable);
 		return getPlaceListResponses(pageable, placeIdPage);
 	}
 
 	@Transactional(readOnly = true)
-	public Page<PlaceListResponse> findAllPlacesByMemberId(Long memberId, Pageable pageable) {
-		Page<Long> placeIdPage = placeRepository.findIdsByMemberId(memberId, pageable);
+	public Page<PlaceListResponse> findAllPlacesByMemberId(Long memberId, Long viewerId, Pageable pageable) {
+
+		List<Long> blockedIds = blockService.getBlockedMemberIds(viewerId);
+		Page<Long> placeIdPage = placeRepository.findIdsByMemberIdExcludingBlocked(memberId, blockedIds, pageable);
 		return getPlaceListResponses(pageable, placeIdPage);
 	}
 
@@ -46,12 +54,7 @@ public class PlaceService {
 
 		return new PageImpl<>(
 			sortedPlaces.stream()
-				.map(place -> new PlaceListResponse(
-					place.getId(),
-					place.getTitle(),
-					place.getRegion(),
-					place.getThumbnailUrl()
-				))
+				.map(PlaceListResponse::of)
 				.toList(),
 			pageable,
 			placeIdPage.getTotalElements()

--- a/src/main/java/com/traveljournal/domain/search/service/MemberSearchService.java
+++ b/src/main/java/com/traveljournal/domain/search/service/MemberSearchService.java
@@ -1,35 +1,44 @@
 package com.traveljournal.domain.search.service;
 
-import com.traveljournal.domain.member.dto.MemberProfileResponse;
-import com.traveljournal.domain.member.entity.Member;
-import com.traveljournal.domain.block.repository.BlockRepository;
-import com.traveljournal.domain.search.dto.MemberSearchResponse;
-import com.traveljournal.domain.search.repository.MemberSearchRepository;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.traveljournal.domain.block.repository.BlockRepository;
+import com.traveljournal.domain.member.dto.MemberProfileResponse;
+import com.traveljournal.domain.member.entity.Member;
+import com.traveljournal.domain.statistics.entity.MemberStatistics;
+import com.traveljournal.domain.statistics.repository.MemberStatisticsRepository;
+import com.traveljournal.domain.search.dto.MemberSearchResponse;
+import com.traveljournal.domain.search.repository.MemberSearchRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class MemberSearchService {
 
     private final MemberSearchRepository memberSearchRepository;
+    private final MemberStatisticsRepository memberStatisticsRepository;
     private final BlockRepository blockRepository;
 
-    @Transactional(readOnly = true)
-    public Page<MemberSearchResponse> searchMembers(String keyword, Pageable pageable) {
-
-        Page<Member> membersPage = memberSearchRepository.findByNicknameContaining(keyword, pageable);
-
-        return membersPage.map(member ->
-                MemberSearchResponse.of(
-                        member.getId(),
-                        MemberProfileResponse.of(member)
-                )
-        );
-    }
+    // @Transactional(readOnly = true)
+    // public Page<MemberSearchResponse> searchMembers(String keyword, Pageable pageable) {
+    //
+    //     Page<Member> membersPage = memberSearchRepository.findByNicknameContaining(keyword, pageable);
+    //
+    //     return membersPage.map(member ->
+    //             MemberSearchResponse.of(
+    //                     member.getId(),
+    //                     MemberProfileResponse.of(member)
+    //             )
+    //     );
+    // }
 
     @Transactional(readOnly = true)
     public Page<MemberSearchResponse> searchByNickname(String keyword, Pageable pageable, Long currentMemberId) {
@@ -37,8 +46,14 @@ public class MemberSearchService {
         // currentMemberId를 넘겨서 repository 쿼리에서 차단 회원 자동 제외
         Page<Member> members = memberSearchRepository.findByNicknameContainingAndIdNotIn(keyword, currentMemberId, pageable);
 
+        List<Long> memberIds = members.stream().map(Member::getId).toList();
+
+        Map<Long, MemberStatistics> statsMap = memberStatisticsRepository.findAllById(memberIds).stream()
+            .collect(Collectors.toMap(MemberStatistics::getMemberId, s -> s));
+
         return members.map(member -> {
-            MemberProfileResponse profile = MemberProfileResponse.of(member);
+            MemberStatistics stats = statsMap.get(member.getId());
+            MemberProfileResponse profile = MemberProfileResponse.of(member, stats);
             return MemberSearchResponse.of(member.getId(), profile);
         });
     }

--- a/src/main/java/com/traveljournal/domain/statistics/entity/MemberRegionStatistics.java
+++ b/src/main/java/com/traveljournal/domain/statistics/entity/MemberRegionStatistics.java
@@ -1,0 +1,35 @@
+package com.traveljournal.domain.statistics.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member_region_statistics")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberRegionStatistics {
+
+	@EmbeddedId
+	private MemberRegionStatisticsId id;
+
+	@Column(nullable = false)
+	private Long travelDiaryCount;
+
+	@Column(nullable = false)
+	private Long placesCount;
+
+	public void increaseTravelDiaryCount() {
+		this.travelDiaryCount++;
+	}
+	public void increasePlacesCount() {
+		this.placesCount++;
+	}
+
+}

--- a/src/main/java/com/traveljournal/domain/statistics/entity/MemberRegionStatisticsId.java
+++ b/src/main/java/com/traveljournal/domain/statistics/entity/MemberRegionStatisticsId.java
@@ -1,0 +1,22 @@
+package com.traveljournal.domain.statistics.entity;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@EqualsAndHashCode
+public class MemberRegionStatisticsId implements Serializable {
+	private Long memberId;
+	private String regionGroup;
+
+	public MemberRegionStatisticsId(Long memberId, String regionGroup) {
+		this.memberId = memberId;
+		this.regionGroup = regionGroup;
+	}
+}

--- a/src/main/java/com/traveljournal/domain/statistics/entity/MemberStatistics.java
+++ b/src/main/java/com/traveljournal/domain/statistics/entity/MemberStatistics.java
@@ -1,0 +1,42 @@
+package com.traveljournal.domain.statistics.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member_statistics")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberStatistics {
+
+	@Id
+	private Long memberId;
+
+	@Column(nullable = false)
+	private Long travelDiaryCount;
+
+	@Column(nullable = false)
+	private Long placesCount;
+
+	@Column(nullable = false)
+	private Long followerCount;
+
+	@Column(nullable = false)
+	private Long followingCount;
+
+	// 도메인 메서드로만 상태 변경
+	public void increaseTravelDiaryCount() {
+		this.travelDiaryCount++;
+	}
+
+	public void decreaseTravelDiaryCount() {
+		this.travelDiaryCount = Math.max(0, this.travelDiaryCount - 1);
+	}
+}

--- a/src/main/java/com/traveljournal/domain/statistics/entity/MemberStatistics.java
+++ b/src/main/java/com/traveljournal/domain/statistics/entity/MemberStatistics.java
@@ -39,4 +39,17 @@ public class MemberStatistics {
 	public void decreaseTravelDiaryCount() {
 		this.travelDiaryCount = Math.max(0, this.travelDiaryCount - 1);
 	}
+
+	public void increaseFollowerCount() {
+		this.followerCount++;
+	}
+	public void decreaseFollowerCount() {
+		this.followerCount = Math.max(0, this.followerCount - 1);
+	}
+	public void increaseFollowingCount() {
+		this.followingCount++;
+	}
+	public void decreaseFollowingCount() {
+		this.followingCount = Math.max(0, this.followingCount - 1);
+	}
 }

--- a/src/main/java/com/traveljournal/domain/statistics/repository/MemberRegionStatisticsRepository.java
+++ b/src/main/java/com/traveljournal/domain/statistics/repository/MemberRegionStatisticsRepository.java
@@ -1,0 +1,12 @@
+package com.traveljournal.domain.statistics.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.traveljournal.domain.statistics.entity.MemberRegionStatistics;
+import com.traveljournal.domain.statistics.entity.MemberRegionStatisticsId;
+
+public interface MemberRegionStatisticsRepository extends JpaRepository<MemberRegionStatistics, MemberRegionStatisticsId> {
+	List<MemberRegionStatistics> findAllByIdMemberId(Long memberId);
+}

--- a/src/main/java/com/traveljournal/domain/statistics/repository/MemberStatisticsRepository.java
+++ b/src/main/java/com/traveljournal/domain/statistics/repository/MemberStatisticsRepository.java
@@ -1,0 +1,7 @@
+package com.traveljournal.domain.statistics.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.traveljournal.domain.statistics.entity.MemberStatistics;
+public interface MemberStatisticsRepository extends JpaRepository<MemberStatistics, Long> {
+}

--- a/src/main/java/com/traveljournal/domain/statistics/service/MemberRegionStatisticsService.java
+++ b/src/main/java/com/traveljournal/domain/statistics/service/MemberRegionStatisticsService.java
@@ -1,0 +1,30 @@
+package com.traveljournal.domain.statistics.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.traveljournal.domain.statistics.entity.MemberRegionStatistics;
+import com.traveljournal.domain.statistics.entity.MemberRegionStatisticsId;
+import com.traveljournal.domain.statistics.repository.MemberRegionStatisticsRepository;
+import com.traveljournal.global.util.RegionNormalizer;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberRegionStatisticsService {
+
+	private final MemberRegionStatisticsRepository memberRegionStatisticsRepository;
+
+	@Transactional
+	public void increaseTravelDiaryCount(Long memberId, String rawRegion) {
+		String regionGroup = RegionNormalizer.normalize(rawRegion);
+		MemberRegionStatisticsId regionStatsId = new MemberRegionStatisticsId(memberId, regionGroup);
+
+		MemberRegionStatistics regionStats = memberRegionStatisticsRepository.findById(regionStatsId)
+			.orElseGet(() -> memberRegionStatisticsRepository.save(
+				new MemberRegionStatistics(regionStatsId, 0L, 0L)
+			));
+		regionStats.increaseTravelDiaryCount();
+	}
+}

--- a/src/main/java/com/traveljournal/domain/statistics/service/MemberStatisticsService.java
+++ b/src/main/java/com/traveljournal/domain/statistics/service/MemberStatisticsService.java
@@ -13,10 +13,38 @@ import lombok.RequiredArgsConstructor;
 public class MemberStatisticsService {
 	private final MemberStatisticsRepository memberStatisticsRepository;
 
+	private MemberStatistics findByMemberId(Long memberId) {
+		return memberStatisticsRepository.findById(memberId)
+			.orElseThrow(() -> new IllegalArgumentException("통계 정보 없음"));
+	}
+
 	@Transactional
 	public void increaseTravelDiaryCount(Long memberId) {
-		MemberStatistics stats = memberStatisticsRepository.findById(memberId)
-			.orElseThrow(() -> new IllegalArgumentException("통계 정보 없음"));
+		MemberStatistics stats = findByMemberId(memberId);
 		stats.increaseTravelDiaryCount();
+	}
+
+	@Transactional
+	public void increaseFollowerCount(Long memberId) {
+		MemberStatistics stats = findByMemberId(memberId);
+		stats.increaseFollowerCount();
+	}
+
+	@Transactional
+	public void increaseFollowingCount(Long memberId) {
+		MemberStatistics stats = findByMemberId(memberId);
+		stats.increaseFollowingCount();
+	}
+
+	@Transactional
+	public void decreaseFollowerCount(Long memberId) {
+		MemberStatistics stats = findByMemberId(memberId);
+		stats.decreaseFollowerCount();
+	}
+
+	@Transactional
+	public void decreaseFollowingCount(Long memberId) {
+		MemberStatistics stats = findByMemberId(memberId);
+		stats.decreaseFollowingCount();
 	}
 }

--- a/src/main/java/com/traveljournal/domain/statistics/service/MemberStatisticsService.java
+++ b/src/main/java/com/traveljournal/domain/statistics/service/MemberStatisticsService.java
@@ -1,0 +1,22 @@
+package com.traveljournal.domain.statistics.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.traveljournal.domain.statistics.entity.MemberStatistics;
+import com.traveljournal.domain.statistics.repository.MemberStatisticsRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberStatisticsService {
+	private final MemberStatisticsRepository memberStatisticsRepository;
+
+	@Transactional
+	public void increaseTravelDiaryCount(Long memberId) {
+		MemberStatistics stats = memberStatisticsRepository.findById(memberId)
+			.orElseThrow(() -> new IllegalArgumentException("통계 정보 없음"));
+		stats.increaseTravelDiaryCount();
+	}
+}

--- a/src/main/java/com/traveljournal/global/exception/ForbiddenException.java
+++ b/src/main/java/com/traveljournal/global/exception/ForbiddenException.java
@@ -1,0 +1,14 @@
+package com.traveljournal.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class ForbiddenException extends RuntimeException {
+	public ForbiddenException(String message, Throwable cause) {
+		super(message, cause);
+	}
+	public ForbiddenException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/traveljournal/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/traveljournal/global/exception/GlobalExceptionHandler.java
@@ -52,4 +52,9 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<String> handleBlockBadRequest(BlockBadRequestException ex) {
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
 	}
+
+	@ExceptionHandler(ForbiddenException.class)
+	public ResponseEntity<String> handleForbiddenException(ForbiddenException ex) {
+		return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
+	}
 }

--- a/src/main/java/com/traveljournal/global/exception/MemberDeleteException.java
+++ b/src/main/java/com/traveljournal/global/exception/MemberDeleteException.java
@@ -1,5 +1,9 @@
 package com.traveljournal.global.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 public class MemberDeleteException extends RuntimeException {
 	public MemberDeleteException(String message, Throwable cause) {
 		super(message, cause);

--- a/src/main/java/com/traveljournal/global/util/RegionNormalizer.java
+++ b/src/main/java/com/traveljournal/global/util/RegionNormalizer.java
@@ -1,0 +1,65 @@
+package com.traveljournal.global.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RegionNormalizer {
+
+	private static final Map<String, String> REGION_MAP = new HashMap<>();
+
+	static {
+		// 수도권
+		REGION_MAP.put("서울", "서울");
+		REGION_MAP.put("서울특별시", "서울");
+		REGION_MAP.put("서울시", "서울");
+
+		REGION_MAP.put("경기", "경기");
+		REGION_MAP.put("경기도", "경기");
+		REGION_MAP.put("경기광역시", "경기");
+
+		REGION_MAP.put("인천", "인천");
+		REGION_MAP.put("인천광역시", "인천");
+		REGION_MAP.put("인천시", "인천");
+
+		// 강원권
+		REGION_MAP.put("강원", "강원도");
+		REGION_MAP.put("강원도", "강원도");
+
+		// 충청권
+		REGION_MAP.put("충청북도", "충청도");
+		REGION_MAP.put("충북", "충청도");
+		REGION_MAP.put("충청남도", "충청도");
+		REGION_MAP.put("충남", "충청도");
+		REGION_MAP.put("충청도", "충청도");
+
+		// 전라권
+		REGION_MAP.put("전라북도", "전라도");
+		REGION_MAP.put("전북", "전라도");
+		REGION_MAP.put("전라남도", "전라도");
+		REGION_MAP.put("전남", "전라도");
+		REGION_MAP.put("전라도", "전라도");
+
+		// 경상권
+		REGION_MAP.put("경상북도", "경상도");
+		REGION_MAP.put("경북", "경상도");
+		REGION_MAP.put("경상남도", "경상도");
+		REGION_MAP.put("경남", "경상도");
+		REGION_MAP.put("경상도", "경상도");
+
+		// 제주권
+		REGION_MAP.put("제주", "제주도");
+		REGION_MAP.put("제주도", "제주도");
+		REGION_MAP.put("제주특별자치도", "제주도");
+	}
+
+	/**
+	 * 입력값을 표준화된 지역명으로 변환합니다.
+	 * @param rawRegion 입력된 지역명(예: "서울특별시", "경북" 등)
+	 * @return 표준화된 지역명(예: "서울", "경상도" 등)
+	 */
+	public static String normalize(String rawRegion) {
+		if (rawRegion == null) return null;
+		String trimmed = rawRegion.trim();
+		return REGION_MAP.getOrDefault(trimmed, trimmed);
+	}
+}


### PR DESCRIPTION
## 🔥 해결된 이슈
- Closes #55 
- jira: TJFE-210
## 📌 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련된 테스트를 추가하거나 기존 테스트를 실행하여 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드를 따랐는지 확인했습니다.
- [x] 배포가 필요한 경우 관련 작업을 완료했습니다. (예: CI/CD 설정, 환경 변수 추가 등)

## ✨ 작업 내용
- [x] 차단 기능 적용
- 홈 대시보드
- 프로필
- 지역구 플레이스
- 지역구 여행일지
- 검색의 경우 구현되어 있으나 추가 설명란에 설명 추가
- 탐험[여행일지]
- [x] 통계 기능 구현
- 전체 총계 [팔로워 수, 팔로잉 수, 전체 플레이스 수, 전체 여행일지 수]
- 지역 총계 [서울, 강원도, 충청도, 경상도, 전라도, 제주도 등의 플레이스 수, 여행일지 수]
- [x] 탐험일지 랜덤 최적화
- 매일 새벽 2시 random_index 셔플 기능 추가
- 조회한 여행일지 데이터 셔플 기능 추가
- [x] 더미데이터 -> 실제 데이터로 변경
- 홈 대시보드
- 프로필
- [x] 부분 리팩토링 진행

## 🚀 추가 설명
> 검색의 경우 차단기능이 구현되어있으나 검색은 되어야한다고 생각합니다. 대신 본인과 검색한 사람의 차단 여부를 알려주거나 들어갔을때 차단한 회원임을 아는 것이 더 낫지 않을까 생각됩니다.

## 📸 테스트 결과 (스크린샷 혹은 로그)
> [스크린샷 혹은 테스트 정상 확인 로그를 첨부해주세요.]

차단 기능 적용한 회원 조회 기능
![image](https://github.com/user-attachments/assets/bfeb84ac-55d1-4664-8f73-da5370266c3d)

차단 기능 적용한 홈 대시보드 기능
![image](https://github.com/user-attachments/assets/a1f254c2-da65-4805-adcb-8968b762fdd7)

여행일지 랜덤 및 차단된 회원 리스트 제거
![image](https://github.com/user-attachments/assets/27776c0e-f805-4367-87c2-7df9631ae4cd)
